### PR TITLE
增加了executor应用

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ats-intc"
+version = "0.1.0"
+dependencies = [
+ "ats-intc-pac",
+ "crossbeam",
+ "log",
+]
+
+[[package]]
+name = "ats-intc-executor"
+version = "0.1.0"
+dependencies = [
+ "ats-intc",
+ "axstd",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "ats-intc-pac"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "vcell",
+]
+
+[[package]]
 name = "ats-intc-test"
 version = "0.1.0"
 dependencies = [
+ "ats-intc",
  "axstd",
 ]
 
@@ -518,6 +545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +604,12 @@ name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -748,6 +790,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
+name = "cortex-m"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
+dependencies = [
+ "bare-metal",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
 name = "crate_interface"
 version = "0.1.1"
 dependencies = [
@@ -799,22 +853,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
+name = "crossbeam"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -827,6 +890,15 @@ checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
 dependencies = [
  "autocfg",
  "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
  "crossbeam-utils",
 ]
 
@@ -1067,7 +1139,7 @@ checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version",
+ "rustc_version 0.4.0",
  "spin 0.9.8",
  "stable_deref_trait",
 ]
@@ -1582,11 +1654,20 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.18",
 ]
 
 [[package]]
@@ -1656,9 +1737,24 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1878,6 +1974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +2018,15 @@ name = "volatile"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+dependencies = [
+ "vcell",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ members = [
     "apps/task/yield",
     "apps/task/priority",
     "apps/task/tls",
-    "apps/ats-intc-test",
+    "apps/ats-intc-test", "apps/ats-intc-executor",
 ]
 
 [profile.release]

--- a/apps/ats-intc-executor/Cargo.toml
+++ b/apps/ats-intc-executor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ats-intc-executor"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axstd = {path = "../../ulib/axstd", features = ["paging", "alloc"]}
+crossbeam-utils = {version = "0.8", default-features = false}
+ats-intc = {path = "../../../ats-intc", default-features = false, features = ["no-simul"]}

--- a/apps/ats-intc-executor/src/executor.rs
+++ b/apps/ats-intc-executor/src/executor.rs
@@ -29,7 +29,7 @@ impl Executor {
             match self.hw_executor.ftask(self.process_id) {
                 Some(task_ref) => {
                     let task_arc = Task::from_ref(task_ref);
-                    let result: Poll<i32> = task_arc.poll_inner();
+                    let result: Poll<i32> = task_arc.poll_inner(self.hw_executor, self.process_id);
                     println!("executor get result {:?}", result);
                 },
                 None => {

--- a/apps/ats-intc-executor/src/executor.rs
+++ b/apps/ats-intc-executor/src/executor.rs
@@ -1,0 +1,59 @@
+﻿use core::hint::spin_loop;
+use core::task::Poll;
+use core::sync::atomic::Ordering;
+
+use alloc::sync::Arc;
+use axstd::println;
+
+use ats_intc::{Task, TaskRef};
+
+const HW_ADDR_BASE: usize = 0xffff_ffc0_0f00_0000;
+
+pub struct Executor {
+    process_id: u32,
+}
+
+impl Executor {
+    pub fn new(process_id: u32) -> Self {
+        Executor{process_id}
+    }
+
+    pub fn spawn(&self, task_ref: TaskRef) {
+        let priority = unsafe { (*task_ref.as_ptr()).priority.load(Ordering::Acquire) };
+
+        unsafe {
+            // 将task_ref写入调度器硬件的对应地址，地址的计算参考https://ats-intc.github.io/docs/ats-intc/01register-space/
+            let hw_addr: usize = HW_ADDR_BASE + (self.process_id as usize) * 0x1000 + 0x30 + (priority as usize) * 0x8;
+            (hw_addr as *mut usize).write_volatile(task_ref.as_ptr() as usize);
+        }
+    }
+
+    fn fetch_task(&self) -> Option<TaskRef> {
+        let task_ptr: usize = unsafe {
+            // 从调度器硬件的对应地址获得task指针，地址的计算参考https://ats-intc.github.io/docs/ats-intc/01register-space/
+            let hw_addr: usize = HW_ADDR_BASE + (self.process_id as usize) * 0x1000 + 0x28;
+            (hw_addr as *const usize).read_volatile()
+        };
+        if task_ptr != 0 {
+            Some(unsafe { TaskRef::from_ptr(task_ptr as *const Task) })
+        }
+        else {
+            None
+        }
+    }
+
+    pub fn run(&self) -> ! {
+        loop {
+            match self.fetch_task() {
+                Some(task_ref) => {
+                    let task_arc = Task::from_ref(task_ref);
+                    let result: Poll<i32> = task_arc.poll_inner();
+                    println!("executor get result {:?}", result);
+                },
+                None => {
+                    spin_loop();
+                }
+            }
+        }
+    }
+}

--- a/apps/ats-intc-executor/src/executor.rs
+++ b/apps/ats-intc-executor/src/executor.rs
@@ -5,46 +5,28 @@ use core::sync::atomic::Ordering;
 use alloc::sync::Arc;
 use axstd::println;
 
-use ats_intc::{Task, TaskRef};
+use ats_intc::{Task, TaskRef, AtsDriver};
 
 const HW_ADDR_BASE: usize = 0xffff_ffc0_0f00_0000;
 
 pub struct Executor {
-    process_id: u32,
+    hw_executor: AtsDriver,
+    process_id: usize,
 }
 
 impl Executor {
-    pub fn new(process_id: u32) -> Self {
-        Executor{process_id}
+    pub fn new(process_id: usize) -> Self {
+        Executor{hw_executor: AtsDriver::new(HW_ADDR_BASE), process_id}
     }
 
     pub fn spawn(&self, task_ref: TaskRef) {
         let priority = unsafe { (*task_ref.as_ptr()).priority.load(Ordering::Acquire) };
-
-        unsafe {
-            // 将task_ref写入调度器硬件的对应地址，地址的计算参考https://ats-intc.github.io/docs/ats-intc/01register-space/
-            let hw_addr: usize = HW_ADDR_BASE + (self.process_id as usize) * 0x1000 + 0x30 + (priority as usize) * 0x8;
-            (hw_addr as *mut usize).write_volatile(task_ref.as_ptr() as usize);
-        }
-    }
-
-    fn fetch_task(&self) -> Option<TaskRef> {
-        let task_ptr: usize = unsafe {
-            // 从调度器硬件的对应地址获得task指针，地址的计算参考https://ats-intc.github.io/docs/ats-intc/01register-space/
-            let hw_addr: usize = HW_ADDR_BASE + (self.process_id as usize) * 0x1000 + 0x28;
-            (hw_addr as *const usize).read_volatile()
-        };
-        if task_ptr != 0 {
-            Some(unsafe { TaskRef::from_ptr(task_ptr as *const Task) })
-        }
-        else {
-            None
-        }
+        self.hw_executor.stask(task_ref, self.process_id, priority as usize);
     }
 
     pub fn run(&self) -> ! {
         loop {
-            match self.fetch_task() {
+            match self.hw_executor.ftask(self.process_id) {
                 Some(task_ref) => {
                     let task_arc = Task::from_ref(task_ref);
                     let result: Poll<i32> = task_arc.poll_inner();

--- a/apps/ats-intc-executor/src/main.rs
+++ b/apps/ats-intc-executor/src/main.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+mod executor;
+
+extern crate alloc;
+use alloc::boxed::Box;
+use axstd::*;
+use executor::Executor;
+use ats_intc::Task;
+use ats_intc::TaskType;
+
+#[no_mangle]
+fn main() {
+    let executor = Executor::new(0);
+    executor.spawn(Task::new(Box::pin(task_test(3)), 3, TaskType::Other));
+    executor.spawn(Task::new(Box::pin(task_test(0)), 0, TaskType::Other));
+    executor.spawn(Task::new(Box::pin(task_test(2)), 2, TaskType::Other));
+    executor.spawn(Task::new(Box::pin(task_test(1)), 1, TaskType::Other));
+    executor.run();
+}
+
+async fn task_test(i: usize) -> i32 {
+    println!("async task priority {i}");
+    0
+}

--- a/apps/ats-intc-test/Cargo.toml
+++ b/apps/ats-intc-test/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 axstd = { path = "../../ulib/axstd", features = ["paging"]}
+ats-intc = {path = "../../../ats-intc", default-features = false, features = ["no-simul"]}
 
 

--- a/apps/ats-intc-test/src/main.rs
+++ b/apps/ats-intc-test/src/main.rs
@@ -1,6 +1,10 @@
 #![no_std]
 #![no_main]
 
+extern crate alloc;
+
+use alloc::sync::Arc;
+use ats_intc::{AtsDriver, Task};
 use axstd::*;
 
 #[no_mangle]
@@ -137,4 +141,19 @@ pub fn test_mmio_region() {
         eih_control.write_volatile(0x4444_4444_4444_4444);
         eih_enqueue_k.write_volatile(0x5555_5555_5555_5555);
     }
+
+    pub fn test_lib() {
+        let executor_base: usize = 0xffff_ffc0_0f00_0000;
+        let lite_executor: AtsDriver = AtsDriver::new(executor_base);
+        let task0: Arc<Task> = Arc::new(Task::new(Box::new(empty_future()), 0, ats_intc::TaskType::Other));
+        let task1: Arc<Task> = Arc::new(Task::new(Box::new(empty_future()), 0, ats_intc::TaskType::Other));
+        let task2: Arc<Task> = Arc::new(Task::new(Box::new(empty_future()), 2, ats_intc::TaskType::Other));
+        let task3: Arc<Task> = Arc::new(Task::new(Box::new(empty_future()), 3, ats_intc::TaskType::Other));
+        task1.update_priority(1);
+
+        lite_executor.load_handler(10, task0.as_ref());
+        lite_executor.stask(task3, 0);
+    }
+
+    async fn empty_future() -> i32 {0}
 }


### PR DESCRIPTION
根据修改后的`ats-intc`库提供的硬件驱动和`Task`数据结构，构建了应用`ats-intc-executor`。其实现了简单的协程调度和运行功能，还未实现Waker和对I/O设备的异步访问。

在`ats-intc-test`应用中，新增了测试`ats-intc`库的代码。