### PR TITLE
为任务调度模块添加异步支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,6 @@ name = "axtask-test"
 version = "0.1.0"
 dependencies = [
  "axstd",
- "axtask",
 ]
 
 [[package]]
@@ -1382,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
 name = "axtask"
 version = "0.1.0"
 dependencies = [
+ "ats-intc",
  "axconfig",
  "axhal",
  "axtask",
@@ -536,6 +537,14 @@ dependencies = [
  "scheduler",
  "spinlock",
  "timer_list",
+]
+
+[[package]]
+name = "axtask-test"
+version = "0.1.0"
+dependencies = [
+ "axstd",
+ "axtask",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,9 @@ members = [
     "apps/task/yield",
     "apps/task/priority",
     "apps/task/tls",
-    "apps/ats-intc-test", "apps/ats-intc-executor",
+    "apps/ats-intc-test",
+    "apps/ats-intc-executor",
+    "apps/axtask-test",
 ]
 
 [profile.release]

--- a/api/arceos_api/src/imp/task.rs
+++ b/api/arceos_api/src/imp/task.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 pub fn ax_sleep_until(deadline: crate::time::AxTimeValue) {
     #[cfg(feature = "multitask")]
     axtask::sleep_until(deadline);
@@ -53,7 +55,7 @@ cfg_task! {
     }
 
     pub fn ax_current_task_id() -> u64 {
-        axtask::current().id().as_u64()
+        axtask::current_id().unwrap()
     }
 
     pub fn ax_spawn<F>(f: F, name: alloc::string::String, stack_size: usize) -> AxTaskHandle
@@ -67,8 +69,21 @@ cfg_task! {
         }
     }
 
+    pub fn ax_spawn_async<F>(f: F, name: alloc::string::String) -> AxTaskHandle
+    where
+        F: Future<Output = i32> + Send + Sync + 'static,
+    {
+        let inner = axtask::spawn_raw_async(f, name);
+        AxTaskHandle {
+            id: inner.id().as_u64(),
+            inner,
+        }
+    }
+
     pub fn ax_wait_for_exit(task: AxTaskHandle) -> Option<i32> {
-        task.inner.join()
+        // TODO
+        // task.inner.join()
+        Some(0)
     }
 
     pub fn ax_set_current_priority(prio: isize) -> crate::AxResult {

--- a/api/arceos_api/src/lib.rs
+++ b/api/arceos_api/src/lib.rs
@@ -81,6 +81,8 @@ pub mod stdio {
 
 /// Multi-threading management.
 pub mod task {
+    use core::future::Future;
+
     define_api_type! {
         @cfg "multitask";
         pub type AxTaskHandle;
@@ -113,6 +115,11 @@ pub mod task {
             f: impl FnOnce() + Send + 'static,
             name: alloc::string::String,
             stack_size: usize
+        ) -> AxTaskHandle;
+        /// Spawns a new async task with the given future and other arguments.
+        pub fn ax_spawn_async(
+            f: impl Future<Output = i32> + Send + Sync + 'static,
+            name: alloc::string::String
         ) -> AxTaskHandle;
         /// Waits for the given task to exit, and returns its exit code (the
         /// argument of [`ax_exit`]).

--- a/apps/ats-intc-test/Cargo.toml
+++ b/apps/ats-intc-test/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 axstd = { path = "../../ulib/axstd", features = ["paging"]}
-ats-intc = {path = "../../../ats-intc", default-features = false, features = ["no-simul"]}
+ats-intc = { path = "../../../ats-intc", default-features = false, features = ["no-simul", "task-as-usize"] }
 
 

--- a/apps/ats-intc-test/src/main.rs
+++ b/apps/ats-intc-test/src/main.rs
@@ -148,13 +148,18 @@ pub fn test_mmio_region() {
 pub fn test_lib() {
     let executor_base: usize = 0xffff_ffc0_0f00_0000;
     let lite_executor: AtsDriver = AtsDriver::new(executor_base);
-    let task0 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
-    let task1 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
-    let task2 = Task::new(Box::pin(empty_future()), 2, ats_intc::TaskType::Other);
-    let task3 = Task::new(Box::pin(empty_future()), 3, ats_intc::TaskType::Other);
-    let task4 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
+    // let task0 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
+    // let task1 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
+    // let task2 = Task::new(Box::pin(empty_future()), 2, ats_intc::TaskType::Other);
+    // let task3 = Task::new(Box::pin(empty_future()), 3, ats_intc::TaskType::Other);
+    // let task4 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
+    let task0: usize = 0;
+    let task1: usize = 1;
+    let task2: usize = 2;
+    let task3: usize = 3;
+    let task4: usize = 4;
     
-    unsafe { (&*task1.as_ptr()).update_priority(1); }
+    // unsafe { (&*task1.as_ptr()).update_priority(1); }
 
     lite_executor.load_handler(10, task0);
     lite_executor.stask(task3, 0 , 3);
@@ -162,13 +167,19 @@ pub fn test_lib() {
     lite_executor.stask(task1, 0 , 1);
     lite_executor.stask(task4, 0 , 0);
 
-    unsafe {
-        println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
-        println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
-        println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
-        println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
-        println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
-    }
+    // unsafe {
+    //     println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
+    //     println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
+    //     println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
+    //     println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
+    //     println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
+    // }
+
+    println!("{:?}", lite_executor.ftask(0).unwrap());
+    println!("{:?}", lite_executor.ftask(0).unwrap());
+    println!("{:?}", lite_executor.ftask(0).unwrap());
+    println!("{:?}", lite_executor.ftask(0).unwrap());
+    // println!("{:?}", lite_executor.ftask(0).unwrap());
 }
 
 async fn empty_future() -> i32 {0}

--- a/apps/axtask-test/Cargo.toml
+++ b/apps/axtask-test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "axtask-test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axstd = { path = "../../ulib/axstd" }
+axtask = { path = "../../modules/axtask" }

--- a/apps/axtask-test/Cargo.toml
+++ b/apps/axtask-test/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axstd = { path = "../../ulib/axstd" }
-axtask = { path = "../../modules/axtask" }
+axstd = { path = "../../ulib/axstd", features = ["paging", "alloc", "multitask"] }
+# axstd = { path = "../../ulib/axstd", features = ["paging", "alloc"] }

--- a/apps/axtask-test/src/main.rs
+++ b/apps/axtask-test/src/main.rs
@@ -1,46 +1,97 @@
 #![no_std]
 #![no_main]
 
+extern crate alloc;
+
+use core::future::Future;
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::Ordering;
+use core::task::Poll;
+
+use alloc::string::String;
+use alloc::string::ToString;
 use axstd::println;
-use axtask::*;
+use axstd::thread;
 
 #[no_mangle]
 fn main() {
-    spawn(||{
+    println!("0.1");
+    thread::spawn(|| {
         println!("1.1");
-        yield_now();
+        thread::yield_now();
         println!("1.2");
-        yield_now();
+        thread::yield_now();
         println!("1.3");
     });
-    spawn(||{
+    thread::spawn(|| {
         println!("2.1");
-        yield_now();
+        thread::yield_now();
         println!("2.2");
-        yield_now();
+        thread::yield_now();
         println!("2.3");
     });
-    spawn(||{
+    thread::spawn(|| {
         println!("3.1");
-        yield_now();
+        thread::yield_now();
         println!("3.2");
-        yield_now();
+        thread::yield_now();
         println!("3.3");
     });
-    spawn_async(async || {
-        atest("4.1").await;
-        println!("4.2");
+    thread::spawn_async(async {
+        println!("4.1");
+        AsyncTest::new("4.2").await;
+        AsyncTest::new("4.3").await;
+        0
     });
-    spawn_async(async || {
-        atest("5.1").await;
-        println!("5.2");
+    thread::spawn_async(async {
+        println!("5.1");
+        AsyncTest::new("5.2").await;
+        AsyncTest::new("5.3").await;
+        0
     });
-    spawn_async(async || {
-        atest("6.1").await;
-        println!("6.2");
+    thread::spawn_async(async {
+        println!("6.1");
+        AsyncTest::new("6.2").await;
+        AsyncTest::new("6.3").await;
+        0
     });
+    println!("0.2");
 }
 
-async fn atest(str: &str) {
-    println!(str);
+struct AsyncTest {
+    a: AtomicBool,
+    string: String,
 }
+
+/// 第一次调用时，返回Pending
+/// 第二次调用时，打印字符串并返回Ready
+impl AsyncTest {
+    fn new(str: &str) -> Self {
+        Self {
+            a: AtomicBool::new(false),
+            string: String::from(str),
+        }
+    }
+}
+
+impl Future for AsyncTest {
+    type Output = ();
+
+    fn poll(self: core::pin::Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> core::task::Poll<Self::Output> {
+        if self.a.load(Ordering::Relaxed) {
+            println!("{}", self.string);
+            self.a.store(false, Ordering::Relaxed);
+            Poll::Ready(())
+        }
+        else {
+            self.a.store(true, Ordering::Relaxed);
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+// #[no_mangle]
+// fn main() {
+//     println!("0.1");
+// }

--- a/apps/axtask-test/src/main.rs
+++ b/apps/axtask-test/src/main.rs
@@ -1,0 +1,46 @@
+#![no_std]
+#![no_main]
+
+use axstd::println;
+use axtask::*;
+
+#[no_mangle]
+fn main() {
+    spawn(||{
+        println!("1.1");
+        yield_now();
+        println!("1.2");
+        yield_now();
+        println!("1.3");
+    });
+    spawn(||{
+        println!("2.1");
+        yield_now();
+        println!("2.2");
+        yield_now();
+        println!("2.3");
+    });
+    spawn(||{
+        println!("3.1");
+        yield_now();
+        println!("3.2");
+        yield_now();
+        println!("3.3");
+    });
+    spawn_async(async || {
+        atest("4.1").await;
+        println!("4.2");
+    });
+    spawn_async(async || {
+        atest("5.1").await;
+        println!("5.2");
+    });
+    spawn_async(async || {
+        atest("6.1").await;
+        println!("6.2");
+    });
+}
+
+async fn atest(str: &str) {
+    println!(str);
+}

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -118,6 +118,52 @@ impl TaskContext {
             context_switch(self, next_ctx)
         }
     }
+
+    #[inline(always)]
+    pub unsafe fn context_store(&mut self) {
+        asm! {
+            "
+            // save old context (callee-saved registers)
+            STR     ra, a0, 0
+            STR     sp, a0, 1
+            STR     s0, a0, 2
+            STR     s1, a0, 3
+            STR     s2, a0, 4
+            STR     s3, a0, 5
+            STR     s4, a0, 6
+            STR     s5, a0, 7
+            STR     s6, a0, 8
+            STR     s7, a0, 9
+            STR     s8, a0, 10
+            STR     s9, a0, 11
+            STR     s10, a0, 12
+            STR     s11, a0, 13
+            "
+        }
+    }
+
+    #[inline(always)]
+    pub unsafe fn context_load(&self) {
+    asm! {
+        "
+        // restore new context
+        LDR     s11, a0, 13
+        LDR     s10, a0, 12
+        LDR     s9, a0, 11
+        LDR     s8, a0, 10
+        LDR     s7, a0, 9
+        LDR     s6, a0, 8
+        LDR     s5, a0, 7
+        LDR     s4, a0, 6
+        LDR     s3, a0, 5
+        LDR     s2, a0, 4
+        LDR     s1, a0, 3
+        LDR     s0, a0, 2
+        LDR     sp, a0, 1
+        LDR     ra, a0, 0
+        "
+    }
+}
 }
 
 #[naked]
@@ -159,4 +205,50 @@ unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task:
         ret",
         options(noreturn),
     )
+}
+
+#[inline(always)]
+pub unsafe fn context_save(_current_task: &mut TaskContext) {
+    asm! {
+        "
+        // save old context (callee-saved registers)
+        STR     ra, a0, 0
+        STR     sp, a0, 1
+        STR     s0, a0, 2
+        STR     s1, a0, 3
+        STR     s2, a0, 4
+        STR     s3, a0, 5
+        STR     s4, a0, 6
+        STR     s5, a0, 7
+        STR     s6, a0, 8
+        STR     s7, a0, 9
+        STR     s8, a0, 10
+        STR     s9, a0, 11
+        STR     s10, a0, 12
+        STR     s11, a0, 13
+        "
+    }
+}
+
+#[inline(always)]
+pub unsafe fn context_load(_next_task: &TaskContext) {
+    asm! {
+        "
+        // restore new context
+        LDR     s11, a1, 13
+        LDR     s10, a1, 12
+        LDR     s9, a1, 11
+        LDR     s8, a1, 10
+        LDR     s7, a1, 9
+        LDR     s6, a1, 8
+        LDR     s5, a1, 7
+        LDR     s4, a1, 6
+        LDR     s3, a1, 5
+        LDR     s2, a1, 4
+        LDR     s1, a1, 3
+        LDR     s0, a1, 2
+        LDR     sp, a1, 1
+        LDR     ra, a1, 0
+        "
+    }
 }

--- a/modules/axruntime/Cargo.toml
+++ b/modules/axruntime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rcore-os/arceos/tree/main/modules/axruntime"
 documentation = "https://rcore-os.github.io/arceos/axruntime/index.html"
 
 [features]
-default = []
+default = ["multitask"]
 
 smp = ["axhal/smp"]
 irq = ["axhal/irq", "axtask?/irq", "percpu", "kernel_guard"]

--- a/modules/axruntime/Cargo.toml
+++ b/modules/axruntime/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rcore-os/arceos/tree/main/modules/axruntime"
 documentation = "https://rcore-os.github.io/arceos/axruntime/index.html"
 
 [features]
-default = ["multitask"]
+default = []
 
 smp = ["axhal/smp"]
 irq = ["axhal/irq", "axtask?/irq", "percpu", "kernel_guard"]

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -149,8 +149,8 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
     info!("Initialize platform devices...");
     axhal::platform_init();
 
-    #[cfg(feature = "multitask")]
-    axtask::init_scheduler();
+    // #[cfg(feature = "multitask")]
+    // axtask::init_scheduler();
 
     #[cfg(any(feature = "fs", feature = "net", feature = "display"))]
     {
@@ -189,12 +189,19 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
         core::hint::spin_loop();
     }
 
-    unsafe { main() };
-
     #[cfg(feature = "multitask")]
-    axtask::exit(0);
+    {
+        axtask::spawn(||{ 
+            unsafe{ 
+                main()
+            } 
+        });
+        axtask::run_executor();
+    }
+    
     #[cfg(not(feature = "multitask"))]
     {
+        unsafe { main() };
         debug!("main task exited: exit_code={}", 0);
         axhal::misc::terminate();
     }

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -74,7 +74,7 @@ impl axlog::LogIf for LogIfImpl {
         if is_init_ok() {
             #[cfg(feature = "multitask")]
             {
-                axtask::current_may_uninit().map(|curr| curr.id().as_u64())
+                axtask::current_id()
             }
             #[cfg(not(feature = "multitask"))]
             None
@@ -149,8 +149,8 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
     info!("Initialize platform devices...");
     axhal::platform_init();
 
-    // #[cfg(feature = "multitask")]
-    // axtask::init_scheduler();
+    #[cfg(feature = "multitask")]
+    axtask::init();
 
     #[cfg(any(feature = "fs", feature = "net", feature = "display"))]
     {
@@ -191,11 +191,14 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
 
     #[cfg(feature = "multitask")]
     {
-        axtask::spawn(||{ 
+        info!("multitask start spawn main");
+        axtask::spawn_init(|| { 
             unsafe{ 
-                main()
+                main();
+                axtask::exit(0);
             } 
         });
+        info!("multitask start run executor");
         axtask::run_executor();
     }
     

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 
 multitask = [
     "dep:axconfig", "dep:percpu", "dep:spinlock", "dep:lazy_init", "dep:memory_addr",
-    "dep:scheduler", "dep:timer_list", "kernel_guard", "dep:crate_interface",
+    "dep:scheduler", "dep:timer_list", "kernel_guard", "dep:crate_interface", "dep:ats-intc"
 ]
 irq = []
 tls = ["axhal/tls"]
@@ -39,7 +39,7 @@ scheduler = { path = "../../crates/scheduler", optional = true }
 timer_list = { path = "../../crates/timer_list", optional = true }
 kernel_guard = { path = "../../crates/kernel_guard", optional = true }
 crate_interface = { path = "../../crates/crate_interface", optional = true }
-ats-intc = { path = "../../../ats-intc", default-features = false, features = ["no-simul", "task-as-usize"] }
+ats-intc = { path = "../../../ats-intc", default-features = false, features = ["no-simul", "task-as-usize"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -39,6 +39,7 @@ scheduler = { path = "../../crates/scheduler", optional = true }
 timer_list = { path = "../../crates/timer_list", optional = true }
 kernel_guard = { path = "../../crates/kernel_guard", optional = true }
 crate_interface = { path = "../../crates/crate_interface", optional = true }
+ats-intc = { path = "../../../ats-intc", default-features = false, features = ["no-simul", "task-as-usize"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -2,15 +2,21 @@
 
 use alloc::{string::String, sync::Arc};
 
-pub(crate) use crate::run_queue::{AxRunQueue, RUN_QUEUE};
+use crate::ats::{ATS_DRIVER, ATS_EXECUTOR, CURRENT_TASK};
+// pub(crate) use crate::run_queue::{AxRunQueue, RUN_QUEUE};
 
+use crate::task::{AbsTaskInner, AsyncTaskInner};
 #[doc(cfg(feature = "multitask"))]
 pub use crate::task::{CurrentTask, TaskId, TaskInner};
 #[doc(cfg(feature = "multitask"))]
 pub use crate::wait_queue::WaitQueue;
 
+use crate::ats::PROCESS_ID;
+
 /// The reference type of a task.
-pub type AxTaskRef = Arc<AxTask>;
+pub type AxTaskRef = Arc<dyn AbsTaskInner>;
+
+use core::future::Future;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "sched_rr")] {
@@ -27,54 +33,55 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(feature = "preempt")]
-struct KernelGuardIfImpl;
+// #[cfg(feature = "preempt")]
+// struct KernelGuardIfImpl;
 
-#[cfg(feature = "preempt")]
-#[crate_interface::impl_interface]
-impl kernel_guard::KernelGuardIf for KernelGuardIfImpl {
-    fn disable_preempt() {
-        if let Some(curr) = current_may_uninit() {
-            curr.disable_preempt();
-        }
-    }
+// #[cfg(feature = "preempt")]
+// #[crate_interface::impl_interface]
+// impl kernel_guard::KernelGuardIf for KernelGuardIfImpl {
+//     fn disable_preempt() {
+//         if let Some(curr) = current_may_uninit() {
+//             curr.disable_preempt();
+//         }
+//     }
 
-    fn enable_preempt() {
-        if let Some(curr) = current_may_uninit() {
-            curr.enable_preempt(true);
-        }
-    }
-}
+//     fn enable_preempt() {
+//         if let Some(curr) = current_may_uninit() {
+//             curr.enable_preempt(true);
+//         }
+//     }
+// }
 
-/// Gets the current task, or returns [`None`] if the current task is not
-/// initialized.
-pub fn current_may_uninit() -> Option<CurrentTask> {
-    CurrentTask::try_get()
-}
+// /// Gets the current task, or returns [`None`] if the current task is not
+// /// initialized.
+// pub fn current_may_uninit() -> Option<CurrentTask> {
+//     CurrentTask::try_get()
+// }
 
 /// Gets the current task.
-///
-/// # Panics
-///
-/// Panics if the current task is not initialized.
 pub fn current() -> CurrentTask {
-    CurrentTask::get()
+    CURRENT_TASK
 }
 
-/// Initializes the task scheduler (for the primary CPU).
-pub fn init_scheduler() {
-    info!("Initialize scheduling...");
+// /// Initializes the task scheduler (for the primary CPU).
+// pub fn init_scheduler() {
+//     info!("Initialize scheduling...");
 
-    crate::run_queue::init();
-    #[cfg(feature = "irq")]
-    crate::timers::init();
+//     crate::run_queue::init();
+//     #[cfg(feature = "irq")]
+//     crate::timers::init();
 
-    info!("  use {} scheduler.", Scheduler::scheduler_name());
-}
+//     info!("  use {} scheduler.", Scheduler::scheduler_name());
+// }
 
-/// Initializes the task scheduler for secondary CPUs.
-pub fn init_scheduler_secondary() {
-    crate::run_queue::init_secondary();
+// /// Initializes the task scheduler for secondary CPUs.
+// pub fn init_scheduler_secondary() {
+//     crate::run_queue::init_secondary();
+// }
+
+/// Run the task executor
+pub fn run_executor() -> ! {
+    ATS_EXECUTOR.run()
 }
 
 /// Handles periodic timer ticks for the task manager.
@@ -95,7 +102,8 @@ where
     F: FnOnce() + Send + 'static,
 {
     let task = TaskInner::new(f, name, stack_size);
-    RUN_QUEUE.lock().add_task(task.clone());
+    let task_ref = task.as_ref() as *const AbsTaskInner as *const _ as usize;
+    ATS_DRIVER.stask(task_ref, PROCESS_ID, task.get_priority());
     task
 }
 
@@ -112,6 +120,32 @@ where
     spawn_raw(f, "".into(), axconfig::TASK_STACK_SIZE)
 }
 
+/// Spawns a new async task with the given parameters.
+///
+/// Returns the task reference.
+pub fn spawn_raw_async<F>(f: F, name: String) -> AxTaskRef
+where
+    F: Future<Output = i32> + Send + Sync,
+{
+    let task = AsyncTaskInner::new(f, name);
+    let task_ref = task.as_ref() as *const AbsTaskInner as *const _ as usize;
+    ATS_DRIVER.stask(task_ref, PROCESS_ID, task.get_priority());
+    task
+}
+
+/// Spawns a new task with the default parameters.
+///
+/// The default task name is an empty string. The default task stack size is
+/// [`axconfig::TASK_STACK_SIZE`].
+///
+/// Returns the task reference.
+pub fn spawn_async<F>(f: F) -> AxTaskRef
+where
+    F: Future<Output = i32> + Send + Sync,
+{
+    spawn_raw_async(f, "".into())
+}
+
 /// Set the priority for current task.
 ///
 /// The range of the priority is dependent on the underlying scheduler. For
@@ -121,46 +155,60 @@ where
 /// Returns `true` if the priority is set successfully.
 ///
 /// [CFS]: https://en.wikipedia.org/wiki/Completely_Fair_Scheduler
-pub fn set_priority(prio: isize) -> bool {
-    RUN_QUEUE.lock().set_current_priority(prio)
+pub fn set_priority(prio: isize) {
+    assert!(prio >= 0);
+    let current = current();
+    current.as_task_ref().unwrap().set_priority(prio as usize);
 }
 
 /// Current task gives up the CPU time voluntarily, and switches to another
 /// ready task.
 pub fn yield_now() {
-    RUN_QUEUE.lock().yield_current();
+    let current_task = current().as_task_ref().unwrap();
+    assert!(!current_task.is_async());
+    unsafe {
+        let sync_task = &*(current_task.as_ref() as *const AbsTaskInner as *const _ as *const TaskInner);
+        sync_task.yield_self();
+    }
 }
 
-/// Current task is going to sleep for the given duration.
-///
-/// If the feature `irq` is not enabled, it uses busy-wait instead.
-pub fn sleep(dur: core::time::Duration) {
-    sleep_until(axhal::time::current_time() + dur);
-}
+// TODO
+// /// Current task is going to sleep for the given duration.
+// ///
+// /// If the feature `irq` is not enabled, it uses busy-wait instead.
+// pub fn sleep(dur: core::time::Duration) {
+//     sleep_until(axhal::time::current_time() + dur);
+// }
 
-/// Current task is going to sleep, it will be woken up at the given deadline.
-///
-/// If the feature `irq` is not enabled, it uses busy-wait instead.
-pub fn sleep_until(deadline: axhal::time::TimeValue) {
-    #[cfg(feature = "irq")]
-    RUN_QUEUE.lock().sleep_until(deadline);
-    #[cfg(not(feature = "irq"))]
-    axhal::time::busy_wait_until(deadline);
-}
+// TODO
+// /// Current task is going to sleep, it will be woken up at the given deadline.
+// ///
+// /// If the feature `irq` is not enabled, it uses busy-wait instead.
+// pub fn sleep_until(deadline: axhal::time::TimeValue) {
+//     #[cfg(feature = "irq")]
+//     RUN_QUEUE.lock().sleep_until(deadline);
+//     #[cfg(not(feature = "irq"))]
+//     axhal::time::busy_wait_until(deadline);
+// }
 
 /// Exits the current task.
 pub fn exit(exit_code: i32) -> ! {
-    RUN_QUEUE.lock().exit_current(exit_code)
-}
-
-/// The idle task routine.
-///
-/// It runs an infinite loop that keeps calling [`yield_now()`].
-pub fn run_idle() -> ! {
-    loop {
-        yield_now();
-        debug!("idle task: waiting for IRQs...");
-        #[cfg(feature = "irq")]
-        axhal::arch::wait_for_irqs();
+    let current_task = current().as_task_ref().unwrap();
+    assert!(!current_task.is_async());
+    unsafe {
+        let sync_task = &*(current_task.as_ref() as *const AbsTaskInner as *const _ as *const TaskInner);
+        sync_task.exit(exit_code);
     }
 }
+
+// /// The idle task routine.
+// ///
+// /// It runs an infinite loop that keeps calling [`yield_now()`].
+// pub fn run_idle() -> ! {
+//     loop {
+//         yield_now();
+//         debug!("idle task: waiting for IRQs...");
+//         #[cfg(feature = "irq")]
+//         axhal::arch::wait_for_irqs();
+//     }
+// }

--- a/modules/axtask/src/ats.rs
+++ b/modules/axtask/src/ats.rs
@@ -1,16 +1,23 @@
-﻿use core::{hint::spin_loop, task::Poll};
+﻿use core::{cell::{RefCell, UnsafeCell}, hint::spin_loop, task::Poll};
 use ats_intc::AtsDriver;
+use axhal::arch::TaskContext;
+use lazy_init::LazyInit;
 use spinlock::SpinNoIrq;
-use crate::{task::{AbsTaskInner, TaskStack}, AxTaskRef, CurrentTask, WaitQueue};
+use crate::{task::{AbsTaskInner, AxTask, TaskStack}, AxTaskRef, CurrentTask, WaitQueue};
 use core::task::{ Context, Waker };
 use alloc::{collections::VecDeque, sync::Arc};
+use core::arch::asm;
+use memory_addr::align_up_4k;
 
-pub(crate) static ATS_DRIVER: AtsDriver = AtsDriver::new(0xffff_ffc0_0f00_0000);
+// pub(crate) static ATS_DRIVER: Lazy<AtsDriver> = Lazy::new(| |{ AtsDriver::new(0xffff_ffc0_0f00_0000) });
+pub(crate) static ATS_DRIVER: LazyInit<AtsDriver> = LazyInit::new();
 pub(crate) const PROCESS_ID: usize = 0;
 
 // scheduler and executor
-pub(crate) static ATS_EXECUTOR: Ats = Ats::new(PROCESS_ID);
-pub(crate) static CURRENT_TASK: CurrentTask = CurrentTask::new();
+// pub(crate) static ATS_EXECUTOR: Lazy<Ats> = Lazy::new(| |{ Ats::new(PROCESS_ID) });
+// pub(crate) static CURRENT_TASK: Lazy<RefCell<CurrentTask>> = Lazy::new(| |{ RefCell::new(CurrentTask::new()) });
+pub(crate) static ATS_EXECUTOR: LazyInit<Ats> = LazyInit::new();
+pub(crate) static CURRENT_TASK: LazyInit<CurrentTask> = LazyInit::new();
 
 // TODO: per-CPU
 pub(crate) static EXITED_TASKS: SpinNoIrq<VecDeque<AxTaskRef>> = SpinNoIrq::new(VecDeque::new());
@@ -20,39 +27,48 @@ pub(crate) static WAIT_FOR_EXIT: WaitQueue = WaitQueue::new();
 pub struct Ats {
     process_id: usize,
     stack: TaskStack,
+    ctx: UnsafeCell<TaskContext>,
 }
 
+unsafe impl Send for Ats { }
 unsafe impl Sync for Ats { }
 
 impl Ats {
-    fn new(process_id: usize) -> Self {
+    pub(crate) fn new(process_id: usize) -> Self {
         Self {
             process_id,
-            stack: TaskStack::alloc(axconfig::TASK_STACK_SIZE),
+            stack: TaskStack::alloc(align_up_4k(axconfig::TASK_STACK_SIZE)),
+            ctx: UnsafeCell::new(TaskContext::new()),
         }
     }
 
     pub(crate) fn run(&self) -> ! {
         loop {
+            info!("  into Ats::run");
             let task = ATS_DRIVER.ftask(self.process_id);
+            info!("  after ftask");
             match task {
                 Some(task_ref) => {
                     unsafe {
-                        let task: Arc<dyn AbsTaskInner> = Arc::from_raw(task_ref as *const ());
-                        CURRENT_TASK.set_current(Some(task));
-                        match task.poll(&mut Context::from_waker(&Waker::from(Arc::new(task.to_waker())))) { 
+                        info!("  ftask: Some");
+                        let task: Arc<AxTask> = Arc::from_raw(task_ref as *const AxTask);
+                        info!("  fetch task: {}.", task.id_name());
+                        CURRENT_TASK.set_current(Some(task.clone()));
+                        match task.poll(&mut Context::from_waker(&Waker::from(task.clone()))) { 
                             Poll::Ready(value) => {
                                 info!("  task return {}.", value);
                             },
                             Poll::Pending => {
-
+                                info!("  task not finished.");
                             },
                         }
                         CURRENT_TASK.set_current(None);
                     }
                 },
                 None => {
-                    spin_loop();
+                    info!("  ftask: None");
+                    // spin_loop();
+                    axhal::misc::terminate();
                 }
             }
         }

--- a/modules/axtask/src/ats.rs
+++ b/modules/axtask/src/ats.rs
@@ -1,0 +1,60 @@
+﻿use core::{hint::spin_loop, task::Poll};
+use ats_intc::AtsDriver;
+use spinlock::SpinNoIrq;
+use crate::{task::{AbsTaskInner, TaskStack}, AxTaskRef, CurrentTask, WaitQueue};
+use core::task::{ Context, Waker };
+use alloc::{collections::VecDeque, sync::Arc};
+
+pub(crate) static ATS_DRIVER: AtsDriver = AtsDriver::new(0xffff_ffc0_0f00_0000);
+pub(crate) const PROCESS_ID: usize = 0;
+
+// scheduler and executor
+pub(crate) static ATS_EXECUTOR: Ats = Ats::new(PROCESS_ID);
+pub(crate) static CURRENT_TASK: CurrentTask = CurrentTask::new();
+
+// TODO: per-CPU
+pub(crate) static EXITED_TASKS: SpinNoIrq<VecDeque<AxTaskRef>> = SpinNoIrq::new(VecDeque::new());
+
+pub(crate) static WAIT_FOR_EXIT: WaitQueue = WaitQueue::new();
+
+pub struct Ats {
+    process_id: usize,
+    stack: TaskStack,
+}
+
+unsafe impl Sync for Ats { }
+
+impl Ats {
+    fn new(process_id: usize) -> Self {
+        Self {
+            process_id,
+            stack: TaskStack::alloc(axconfig::TASK_STACK_SIZE),
+        }
+    }
+
+    pub(crate) fn run(&self) -> ! {
+        loop {
+            let task = ATS_DRIVER.ftask(self.process_id);
+            match task {
+                Some(task_ref) => {
+                    unsafe {
+                        let task: Arc<dyn AbsTaskInner> = Arc::from_raw(task_ref as *const ());
+                        CURRENT_TASK.set_current(Some(task));
+                        match task.poll(&mut Context::from_waker(&Waker::from(Arc::new(task.to_waker())))) { 
+                            Poll::Ready(value) => {
+                                info!("  task return {}.", value);
+                            },
+                            Poll::Pending => {
+
+                            },
+                        }
+                        CURRENT_TASK.set_current(None);
+                    }
+                },
+                None => {
+                    spin_loop();
+                }
+            }
+        }
+    }
+}

--- a/modules/axtask/src/lib.rs
+++ b/modules/axtask/src/lib.rs
@@ -35,17 +35,19 @@ cfg_if::cfg_if! {
         extern crate log;
         extern crate alloc;
 
-        mod run_queue;
+        // mod run_queue;
         mod task;
         mod api;
         mod wait_queue;
+        mod ats;
 
         #[cfg(feature = "irq")]
         mod timers;
 
         #[doc(cfg(feature = "multitask"))]
         pub use self::api::*;
-        pub use self::api::{sleep, sleep_until, yield_now};
+        // pub use self::api::{sleep, sleep_until, yield_now};
+        pub use self::api::yield_now;
     } else {
         mod api_s;
         pub use self::api_s::{sleep, sleep_until, yield_now};

--- a/modules/axtask/src/run_queue.rs
+++ b/modules/axtask/src/run_queue.rs
@@ -11,9 +11,9 @@ use crate::{AxTaskRef, Scheduler, TaskInner, WaitQueue};
 pub(crate) static RUN_QUEUE: LazyInit<SpinNoIrq<AxRunQueue>> = LazyInit::new();
 
 // TODO: per-CPU
-static EXITED_TASKS: SpinNoIrq<VecDeque<AxTaskRef>> = SpinNoIrq::new(VecDeque::new());
+pub(crate) static EXITED_TASKS: SpinNoIrq<VecDeque<AxTaskRef>> = SpinNoIrq::new(VecDeque::new());
 
-static WAIT_FOR_EXIT: WaitQueue = WaitQueue::new();
+pub(crate) static WAIT_FOR_EXIT: WaitQueue = WaitQueue::new();
 
 #[percpu::def_percpu]
 static IDLE_TASK: LazyInit<AxTaskRef> = LazyInit::new();
@@ -185,7 +185,7 @@ impl AxRunQueue {
             assert!(Arc::strong_count(prev_task.as_task_ref()) > 1);
             assert!(Arc::strong_count(&next_task) >= 1);
 
-            CurrentTask::set_current(prev_task, next_task);
+            // CurrentTask::set_current(prev_task, next_task);
             (*prev_ctx_ptr).switch_to(&*next_ctx_ptr);
         }
     }

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -1,7 +1,14 @@
+use alloc::task::Wake;
 use alloc::{boxed::Box, string::String, sync::Arc};
+use core::future::Future;
 use core::ops::Deref;
-use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicU8, Ordering};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
+use core::task::{Context, Poll};
 use core::{alloc::Layout, cell::UnsafeCell, fmt, ptr::NonNull};
+
+use core::arch::asm;
+use ats_intc::AtsDriver;
 
 #[cfg(feature = "preempt")]
 use core::sync::atomic::AtomicUsize;
@@ -10,9 +17,34 @@ use core::sync::atomic::AtomicUsize;
 use axhal::tls::TlsArea;
 
 use axhal::arch::TaskContext;
-use memory_addr::{align_up_4k, VirtAddr};
+use memory_addr::{align_up_4k, VirtAddr, PAGE_SIZE_4K};
 
-use crate::{AxRunQueue, AxTask, AxTaskRef, WaitQueue};
+use crate::ats::PROCESS_ID;
+use crate::ats::{EXITED_TASKS, WAIT_FOR_EXIT};
+use crate::{AxTask, AxTaskRef, WaitQueue};
+use crate::ats::ATS_DRIVER;
+
+pub trait AbsTaskInner: UnpinFuture<Output = i32> + TaskInfo + Send + Sync {
+    fn to_waker(self: Arc<Self>) -> AbsTaskWaker {
+        AbsTaskWaker {
+            inner: Arc::clone(self),
+        }
+    }
+}
+impl AbsTaskInner for TaskInner { }
+impl AbsTaskInner for AsyncTaskInner { }
+
+pub struct AbsTaskWaker {
+    inner: AxTaskRef,
+}
+
+impl Wake for AbsTaskWaker {
+    fn wake(self: Arc<Self>) {
+        self.inner.set_state(TaskState::Ready);
+        let task_ref = self.inner.as_ref() as *const AbsTaskInner as *const _ as usize;
+        ATS_DRIVER.stask(task_ref, PROCESS_ID, self.inner.get_priority());
+    }
+}
 
 /// A unique identifier for a thread.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -37,6 +69,7 @@ pub struct TaskInner {
 
     entry: Option<*mut dyn FnOnce()>,
     state: AtomicU8,
+    priority: AtomicUsize,
 
     in_wait_queue: AtomicBool,
     #[cfg(feature = "irq")]
@@ -55,6 +88,10 @@ pub struct TaskInner {
 
     #[cfg(feature = "tls")]
     tls: TlsArea,
+
+    
+    executor_ra: AtomicUsize,
+    executor_sp: AtomicUsize,
 }
 
 impl TaskId {
@@ -85,22 +122,257 @@ impl From<u8> for TaskState {
 unsafe impl Send for TaskInner {}
 unsafe impl Sync for TaskInner {}
 
+pub(crate) trait UnpinFuture {
+    type Output;
+    fn poll(&self, cx: &mut Context<'_>) -> Poll<Self::Output>;
+}
+
+impl UnpinFuture for TaskInner {
+    type Output = i32;
+    
+    fn poll(&self, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut ra: usize = 0;
+        let mut sp: usize = 0;
+        unsafe {
+            asm! {
+                "
+                    MOV     t0, ra
+                    MOV     t1, sp
+                ",
+                out("t0") ra,
+                out("t1") sp,
+            };
+        }
+        self.executor_ra.store(ra, Ordering::Relaxed);
+        self.executor_sp.store(sp, Ordering::Relaxed);
+
+        unsafe {
+            self.ctx_mut_ptr().as_mut().unwrap().context_load();
+            asm! {
+                "RET"
+            }
+        }
+
+        return Poll::Ready(-1); // unreachable
+    }
+}
+
+impl Wake for TaskInner {
+    fn wake(self: Arc<Self>) {
+        self.set_state(TaskState::Ready);
+        let task_ref = self.as_ref() as *const TaskInner as usize;
+        ATS_DRIVER.stask(task_ref, PROCESS_ID, self.get_priority());
+    }
+}
+
+// related to async
 impl TaskInner {
+    pub fn yield_self(&self) {
+        assert!(self.is_running());
+        self.set_state(TaskState::Ready);
+
+        // TODO: Call Waker
+
+        unsafe {
+            self.ctx_mut_ptr().as_mut().unwrap().context_store();
+            
+            let ra = self.executor_ra.load(Ordering::Relaxed);
+            let sp = self.executor_sp.load(Ordering::Relaxed);
+            asm! {
+                "
+                    MOV     ra, t0
+                    MOV     sp, t1
+                    // return Poll::Pending to Executor
+                    LI      a0, 1
+                    RET
+                ",
+                in("t0") ra,
+                in("t1") sp,
+            }
+        }
+    }
+
+    pub fn exit(&self, exit_code: i32) -> ! {
+        assert!(self.is_running());
+        assert!(!self.is_idle());
+        if self.is_init() {
+            EXITED_TASKS.lock().clear();
+            axhal::misc::terminate();
+        } else {
+            self.set_state(TaskState::Exited);
+            self.exit_code.store(exit_code, Ordering::Release);
+            self.wait_for_exit.notify_all_locked(false);
+            EXITED_TASKS.lock().push_back(unsafe { Arc::from_raw(self as *const Self) });
+            WAIT_FOR_EXIT.notify_one_locked(false);
+            
+            unsafe {
+                let ra = self.executor_ra.load(Ordering::Relaxed);
+                let sp = self.executor_sp.load(Ordering::Relaxed);
+                asm! {
+                    "
+                        MOV     ra, t0
+                        MOV     sp, t1
+                        // return Poll::Ready(exit_code) to Executor
+                        LI      a0, 0
+                        MOV     a1, t2
+                        RET
+                    ",
+                    in("t0") ra,
+                    in("t1") sp,
+                    in("t2") exit_code,
+                }
+            }
+
+            unreachable!();
+        }
+    }
+}
+
+pub trait TaskInfo {
     /// Gets the ID of the task.
-    pub const fn id(&self) -> TaskId {
+    fn id(&self) -> TaskId;
+
+    /// Gets the name of the task.
+    fn name(&self) -> &str;
+
+    /// Get a combined string of the task ID and name.
+    fn id_name(&self) -> alloc::string::String;
+
+    #[inline]
+    fn state(&self) -> TaskState;
+
+    #[inline]
+    fn set_state(&self, state: TaskState);
+
+    #[inline]
+    fn is_running(&self) -> bool;
+
+    #[inline]
+    fn is_ready(&self) -> bool;
+
+    #[inline]
+    fn is_blocked(&self) -> bool;
+
+    #[inline]
+    fn get_priority(&self) -> usize;
+
+    #[inline]
+    fn set_priority(&self, priority: usize);
+
+    #[inline]
+    fn is_init(&self) -> bool;
+
+    #[inline]
+    fn is_idle(&self) -> bool;
+
+    #[inline]
+    fn in_wait_queue(&self) -> bool;
+
+    #[inline]
+    fn set_in_wait_queue(&self, in_wait_queue: bool);
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    fn in_timer_list(&self) -> bool;
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    fn set_in_timer_list(&self, in_timer_list: bool);
+
+    #[inline]
+    fn is_async(&self) -> bool;
+}
+
+impl TaskInfo for TaskInner {
+    /// Gets the ID of the task.
+    fn id(&self) -> TaskId {
         self.id
     }
 
     /// Gets the name of the task.
-    pub fn name(&self) -> &str {
+    fn name(&self) -> &str {
         self.name.as_str()
     }
 
     /// Get a combined string of the task ID and name.
-    pub fn id_name(&self) -> alloc::string::String {
+    fn id_name(&self) -> alloc::string::String {
         alloc::format!("Task({}, {:?})", self.id.as_u64(), self.name)
     }
 
+    #[inline]
+    fn state(&self) -> TaskState {
+        self.state.load(Ordering::Acquire).into()
+    }
+
+    #[inline]
+    fn set_state(&self, state: TaskState) {
+        self.state.store(state as u8, Ordering::Release)
+    }
+
+    #[inline]
+    fn is_running(&self) -> bool {
+        matches!(self.state(), TaskState::Running)
+    }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
+        matches!(self.state(), TaskState::Ready)
+    }
+
+    #[inline]
+    fn is_blocked(&self) -> bool {
+        matches!(self.state(), TaskState::Blocked)
+    }
+
+    #[inline]
+    fn get_priority(&self) -> usize {
+        self.priority.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    fn set_priority(&self, priority: usize) {
+        self.priority.store(priority, Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn is_init(&self) -> bool {
+        self.is_init
+    }
+
+    #[inline]
+    fn is_idle(&self) -> bool {
+        self.is_idle
+    }
+
+    #[inline]
+    fn in_wait_queue(&self) -> bool {
+        self.in_wait_queue.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    fn set_in_wait_queue(&self, in_wait_queue: bool) {
+        self.in_wait_queue.store(in_wait_queue, Ordering::Release);
+    }
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    fn in_timer_list(&self) -> bool {
+        self.in_timer_list.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    fn set_in_timer_list(&self, in_timer_list: bool) {
+        self.in_timer_list.store(in_timer_list, Ordering::Release);
+    }
+    
+    #[inline]
+    fn is_async(&self) -> bool {
+        false
+    }
+}
+
+impl TaskInner {
     /// Wait for the task to exit, and return the exit code.
     ///
     /// It will return immediately if the task has already exited (but not dropped).
@@ -121,6 +393,7 @@ impl TaskInner {
             is_init: false,
             entry: None,
             state: AtomicU8::new(TaskState::Ready as u8),
+            priority: AtomicUsize::new(1),
             in_wait_queue: AtomicBool::new(false),
             #[cfg(feature = "irq")]
             in_timer_list: AtomicBool::new(false),
@@ -134,6 +407,9 @@ impl TaskInner {
             ctx: UnsafeCell::new(TaskContext::new()),
             #[cfg(feature = "tls")]
             tls: TlsArea::alloc(),
+            
+            executor_ra: AtomicUsize::new(0),
+            executor_sp: AtomicUsize::new(0),
         }
     }
 
@@ -157,7 +433,7 @@ impl TaskInner {
         if t.name == "idle" {
             t.is_idle = true;
         }
-        Arc::new(AxTask::new(t))
+        Arc::new(t)
     }
 
     /// Creates an "init task" using the current CPU states, to use as the
@@ -174,64 +450,7 @@ impl TaskInner {
         if t.name == "idle" {
             t.is_idle = true;
         }
-        Arc::new(AxTask::new(t))
-    }
-
-    #[inline]
-    pub(crate) fn state(&self) -> TaskState {
-        self.state.load(Ordering::Acquire).into()
-    }
-
-    #[inline]
-    pub(crate) fn set_state(&self, state: TaskState) {
-        self.state.store(state as u8, Ordering::Release)
-    }
-
-    #[inline]
-    pub(crate) fn is_running(&self) -> bool {
-        matches!(self.state(), TaskState::Running)
-    }
-
-    #[inline]
-    pub(crate) fn is_ready(&self) -> bool {
-        matches!(self.state(), TaskState::Ready)
-    }
-
-    #[inline]
-    pub(crate) fn is_blocked(&self) -> bool {
-        matches!(self.state(), TaskState::Blocked)
-    }
-
-    #[inline]
-    pub(crate) const fn is_init(&self) -> bool {
-        self.is_init
-    }
-
-    #[inline]
-    pub(crate) const fn is_idle(&self) -> bool {
-        self.is_idle
-    }
-
-    #[inline]
-    pub(crate) fn in_wait_queue(&self) -> bool {
-        self.in_wait_queue.load(Ordering::Acquire)
-    }
-
-    #[inline]
-    pub(crate) fn set_in_wait_queue(&self, in_wait_queue: bool) {
-        self.in_wait_queue.store(in_wait_queue, Ordering::Release);
-    }
-
-    #[inline]
-    #[cfg(feature = "irq")]
-    pub(crate) fn in_timer_list(&self) -> bool {
-        self.in_timer_list.load(Ordering::Acquire)
-    }
-
-    #[inline]
-    #[cfg(feature = "irq")]
-    pub(crate) fn set_in_timer_list(&self, in_timer_list: bool) {
-        self.in_timer_list.store(in_timer_list, Ordering::Release);
+        Arc::new(t)
     }
 
     #[inline]
@@ -272,10 +491,10 @@ impl TaskInner {
         }
     }
 
-    pub(crate) fn notify_exit(&self, exit_code: i32, rq: &mut AxRunQueue) {
-        self.exit_code.store(exit_code, Ordering::Release);
-        self.wait_for_exit.notify_all_locked(false, rq);
-    }
+    // pub(crate) fn notify_exit(&self, exit_code: i32) {
+    //     self.exit_code.store(exit_code, Ordering::Release);
+    //     self.wait_for_exit.notify_all_locked(false);
+    // }
 
     #[inline]
     pub(crate) const unsafe fn ctx_mut_ptr(&self) -> *mut TaskContext {
@@ -299,7 +518,159 @@ impl Drop for TaskInner {
     }
 }
 
-struct TaskStack {
+/// The inner coroutine structure.
+pub struct AsyncTaskInner {
+    id: TaskId,
+    name: String,
+    is_idle: bool,
+    is_init: bool,
+    state: AtomicU8,
+    priority: AtomicUsize,
+
+    in_wait_queue: AtomicBool,
+    #[cfg(feature = "irq")]
+    in_timer_list: AtomicBool,
+
+    wait_for_exit: WaitQueue,
+
+    fut: UnsafeCell<Pin<Box<dyn Future<Output = i32> + Send + Sync>>>,
+}
+
+unsafe impl Send for AsyncTaskInner { }
+unsafe impl Sync for AsyncTaskInner { }
+
+impl UnpinFuture for AsyncTaskInner {
+    type Output = i32;
+
+    fn poll(&self, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.set_state(TaskState::Running);
+        let res = unsafe { self.fut.get().as_mut().unwrap().as_mut().poll(cx) };
+        self.set_state(TaskState::Blocked);
+        res
+    }
+}
+
+impl Wake for AsyncTaskInner {
+    fn wake(self: Arc<Self>) {
+        self.set_state(TaskState::Ready);
+        let task_ref = self.as_ref() as *const AsyncTaskInner as usize;
+        ATS_DRIVER.stask(task_ref, PROCESS_ID, self.get_priority());
+    }
+}
+
+impl TaskInfo for AsyncTaskInner {
+    /// Gets the ID of the task.
+    fn id(&self) -> TaskId {
+        self.id
+    }
+
+    /// Gets the name of the task.
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// Get a combined string of the task ID and name.
+    fn id_name(&self) -> alloc::string::String {
+        alloc::format!("Task({}, {:?})", self.id.as_u64(), self.name)
+    }
+
+    #[inline]
+    fn state(&self) -> TaskState {
+        self.state.load(Ordering::Acquire).into()
+    }
+
+    #[inline]
+    fn set_state(&self, state: TaskState) {
+        self.state.store(state as u8, Ordering::Release)
+    }
+
+    #[inline]
+    fn is_running(&self) -> bool {
+        matches!(self.state(), TaskState::Running)
+    }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
+        matches!(self.state(), TaskState::Ready)
+    }
+
+    #[inline]
+    fn is_blocked(&self) -> bool {
+        matches!(self.state(), TaskState::Blocked)
+    }
+
+    #[inline]
+    fn get_priority(&self) -> usize {
+        self.priority.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    fn set_priority(&self, priority: usize) {
+        self.priority.store(priority, Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn is_init(&self) -> bool {
+        self.is_init
+    }
+
+    #[inline]
+    fn is_idle(&self) -> bool {
+        self.is_idle
+    }
+
+    #[inline]
+    fn in_wait_queue(&self) -> bool {
+        self.in_wait_queue.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    fn set_in_wait_queue(&self, in_wait_queue: bool) {
+        self.in_wait_queue.store(in_wait_queue, Ordering::Release);
+    }
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    fn in_timer_list(&self) -> bool {
+        self.in_timer_list.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    fn set_in_timer_list(&self, in_timer_list: bool) {
+        self.in_timer_list.store(in_timer_list, Ordering::Release);
+    }
+    
+    #[inline]
+    fn is_async(&self) -> bool {
+        true
+    }
+}
+
+impl AsyncTaskInner {
+    /// Create a new task with the given entry function and stack size.
+    pub(crate) fn new<F>(fut: F, name: String) -> Arc<dyn AbsTaskInner>
+    where
+        F: Future<Output = i32> + Send + Sync
+    {
+        let mut t = Self {
+            id: TaskId::new(),
+            name,
+            is_idle: false,
+            is_init: false,
+            state: AtomicU8::new(TaskState::Ready as u8),
+            priority: AtomicUsize::new(1),
+            in_wait_queue: AtomicBool::new(false),
+            #[cfg(feature = "irq")]
+            in_timer_list: AtomicBool::new(false),
+            wait_for_exit: WaitQueue::new(),
+            fut: UnsafeCell::new(Box::pin(fut))
+        };
+        Arc::new(t)
+    }
+}
+
+pub(crate) struct TaskStack {
     ptr: NonNull<u8>,
     layout: Layout,
 }
@@ -324,67 +695,82 @@ impl Drop for TaskStack {
     }
 }
 
-use core::mem::ManuallyDrop;
+use core::mem::{self, ManuallyDrop};
 
 /// A wrapper of [`AxTaskRef`] as the current task.
-pub struct CurrentTask(ManuallyDrop<AxTaskRef>);
+/// `None` indecates current task is executor.
+pub struct CurrentTask(Option<ManuallyDrop<AxTaskRef>>);
 
 impl CurrentTask {
-    pub(crate) fn try_get() -> Option<Self> {
-        let ptr: *const super::AxTask = axhal::cpu::current_task_ptr();
-        if !ptr.is_null() {
-            Some(Self(unsafe { ManuallyDrop::new(AxTaskRef::from_raw(ptr)) }))
-        } else {
-            None
-        }
-    }
+    // pub(crate) fn try_get() -> Option<Self> {
+    //     let ptr: *const super::AxTask = axhal::cpu::current_task_ptr();
+    //     if !ptr.is_null() {
+    //         Some(Self(unsafe { ManuallyDrop::new(AxTaskRef::from_raw(ptr)) }))
+    //     } else {
+    //         None
+    //     }
+    // }
 
-    pub(crate) fn get() -> Self {
-        Self::try_get().expect("current task is uninitialized")
-    }
+    // pub(crate) fn get() -> Self {
+    //     Self::try_get().expect("current task is uninitialized")
+    // }
+
+    pub fn new() -> Self {
+        Self {
+            0: None
+        }
+    } 
 
     /// Converts [`CurrentTask`] to [`AxTaskRef`].
-    pub fn as_task_ref(&self) -> &AxTaskRef {
-        &self.0
+    pub fn as_task_ref(&self) -> Option<AxTaskRef> {
+        self.0.map(|a| { ManuallyDrop::into_inner(a) })
     }
 
-    pub(crate) fn clone(&self) -> AxTaskRef {
-        self.0.deref().clone()
+    pub(crate) fn clone(&self) -> Option<AxTaskRef> {
+        self.0.map(|a| { ManuallyDrop::into_inner(a).clone() })
     }
 
     pub(crate) fn ptr_eq(&self, other: &AxTaskRef) -> bool {
-        Arc::ptr_eq(&self.0, other)
+        if self.0.is_none() { false }
+        else {
+            Arc::ptr_eq(&self.0.unwrap(), other)
+        }
     }
 
-    pub(crate) unsafe fn init_current(init_task: AxTaskRef) {
-        #[cfg(feature = "tls")]
-        axhal::arch::write_thread_pointer(init_task.tls.tls_ptr() as usize);
-        let ptr = Arc::into_raw(init_task);
-        axhal::cpu::set_current_task_ptr(ptr);
-    }
+    // pub(crate) unsafe fn init_current(init_task: AxTaskRef) {
+    //     #[cfg(feature = "tls")]
+    //     axhal::arch::write_thread_pointer(init_task.tls.tls_ptr() as usize);
+    //     let ptr = Arc::into_raw(init_task);
+    //     axhal::cpu::set_current_task_ptr(ptr);
+    // }
 
-    pub(crate) unsafe fn set_current(prev: Self, next: AxTaskRef) {
-        let Self(arc) = prev;
-        ManuallyDrop::into_inner(arc); // `call Arc::drop()` to decrease prev task reference count.
-        let ptr = Arc::into_raw(next);
-        axhal::cpu::set_current_task_ptr(ptr);
+    pub(crate) unsafe fn set_current(&mut self, next: Option<AxTaskRef>) {
+        let old = mem::replace(self, CurrentTask {0: next.map(|a| { ManuallyDrop::new(a) })});
+        let Self(opt) = old;
+        if let Some(arc) = opt {
+            ManuallyDrop::into_inner(arc); // `call Arc::drop()` to decrease prev task reference count.
+        }
+        // self.0 = next.map(|a| { ManuallyDrop::new(a) });
+        // axhal::cpu::set_current_task_ptr(ptr);
     }
 }
 
 impl Deref for CurrentTask {
-    type Target = TaskInner;
+    type Target = dyn AbsTaskInner;
     fn deref(&self) -> &Self::Target {
-        self.0.deref()
+        self.0.unwrap().deref()
     }
 }
 
 extern "C" fn task_entry() -> ! {
-    // release the lock that was implicitly held across the reschedule
-    unsafe { crate::RUN_QUEUE.force_unlock() };
+    // // release the lock that was implicitly held across the reschedule
+    // unsafe { crate::RUN_QUEUE.force_unlock() };
     #[cfg(feature = "irq")]
     axhal::arch::enable_irqs();
-    let task = crate::current();
-    if let Some(entry) = task.entry {
+    let task = crate::current().as_task_ref().unwrap();
+    assert!(!task.is_async());
+    let inner = task.as_ref() as *const dyn AbsTaskInner as *const _ as *const TaskInner as &TaskInner;
+    if let Some(entry) = inner.entry {
         unsafe { Box::from_raw(entry)() };
     }
     crate::exit(0);

--- a/modules/axtask/src/task.rs.old
+++ b/modules/axtask/src/task.rs.old
@@ -1,0 +1,391 @@
+use alloc::{boxed::Box, string::String, sync::Arc};
+use core::ops::Deref;
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicU8, Ordering};
+use core::{alloc::Layout, cell::UnsafeCell, fmt, ptr::NonNull};
+
+#[cfg(feature = "preempt")]
+use core::sync::atomic::AtomicUsize;
+
+#[cfg(feature = "tls")]
+use axhal::tls::TlsArea;
+
+use axhal::arch::TaskContext;
+use memory_addr::{align_up_4k, VirtAddr};
+
+use crate::{AxRunQueue, AxTask, AxTaskRef, WaitQueue};
+
+/// A unique identifier for a thread.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TaskId(u64);
+
+/// The possible states of a task.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum TaskState {
+    Running = 1,
+    Ready = 2,
+    Blocked = 3,
+    Exited = 4,
+}
+
+/// The inner task structure.
+pub struct TaskInner {
+    id: TaskId,
+    name: String,
+    is_idle: bool,
+    is_init: bool,
+
+    entry: Option<*mut dyn FnOnce()>,
+    state: AtomicU8,
+
+    in_wait_queue: AtomicBool,
+    #[cfg(feature = "irq")]
+    in_timer_list: AtomicBool,
+
+    #[cfg(feature = "preempt")]
+    need_resched: AtomicBool,
+    #[cfg(feature = "preempt")]
+    preempt_disable_count: AtomicUsize,
+
+    exit_code: AtomicI32,
+    wait_for_exit: WaitQueue,
+
+    kstack: Option<TaskStack>,
+    ctx: UnsafeCell<TaskContext>,
+
+    #[cfg(feature = "tls")]
+    tls: TlsArea,
+}
+
+impl TaskId {
+    fn new() -> Self {
+        static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+        Self(ID_COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Convert the task ID to a `u64`.
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u8> for TaskState {
+    #[inline]
+    fn from(state: u8) -> Self {
+        match state {
+            1 => Self::Running,
+            2 => Self::Ready,
+            3 => Self::Blocked,
+            4 => Self::Exited,
+            _ => unreachable!(),
+        }
+    }
+}
+
+unsafe impl Send for TaskInner {}
+unsafe impl Sync for TaskInner {}
+
+impl TaskInner {
+    /// Gets the ID of the task.
+    pub const fn id(&self) -> TaskId {
+        self.id
+    }
+
+    /// Gets the name of the task.
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// Get a combined string of the task ID and name.
+    pub fn id_name(&self) -> alloc::string::String {
+        alloc::format!("Task({}, {:?})", self.id.as_u64(), self.name)
+    }
+
+    /// Wait for the task to exit, and return the exit code.
+    ///
+    /// It will return immediately if the task has already exited (but not dropped).
+    pub fn join(&self) -> Option<i32> {
+        self.wait_for_exit
+            .wait_until(|| self.state() == TaskState::Exited);
+        Some(self.exit_code.load(Ordering::Acquire))
+    }
+}
+
+// private methods
+impl TaskInner {
+    fn new_common(id: TaskId, name: String) -> Self {
+        Self {
+            id,
+            name,
+            is_idle: false,
+            is_init: false,
+            entry: None,
+            state: AtomicU8::new(TaskState::Ready as u8),
+            in_wait_queue: AtomicBool::new(false),
+            #[cfg(feature = "irq")]
+            in_timer_list: AtomicBool::new(false),
+            #[cfg(feature = "preempt")]
+            need_resched: AtomicBool::new(false),
+            #[cfg(feature = "preempt")]
+            preempt_disable_count: AtomicUsize::new(0),
+            exit_code: AtomicI32::new(0),
+            wait_for_exit: WaitQueue::new(),
+            kstack: None,
+            ctx: UnsafeCell::new(TaskContext::new()),
+            #[cfg(feature = "tls")]
+            tls: TlsArea::alloc(),
+        }
+    }
+
+    /// Create a new task with the given entry function and stack size.
+    pub(crate) fn new<F>(entry: F, name: String, stack_size: usize) -> AxTaskRef
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let mut t = Self::new_common(TaskId::new(), name);
+        debug!("new task: {}", t.id_name());
+        let kstack = TaskStack::alloc(align_up_4k(stack_size));
+
+        #[cfg(feature = "tls")]
+        let tls = VirtAddr::from(t.tls.tls_ptr() as usize);
+        #[cfg(not(feature = "tls"))]
+        let tls = VirtAddr::from(0);
+
+        t.entry = Some(Box::into_raw(Box::new(entry)));
+        t.ctx.get_mut().init(task_entry as usize, kstack.top(), tls);
+        t.kstack = Some(kstack);
+        if t.name == "idle" {
+            t.is_idle = true;
+        }
+        Arc::new(AxTask::new(t))
+    }
+
+    /// Creates an "init task" using the current CPU states, to use as the
+    /// current task.
+    ///
+    /// As it is the current task, no other task can switch to it until it
+    /// switches out.
+    ///
+    /// And there is no need to set the `entry`, `kstack` or `tls` fields, as
+    /// they will be filled automatically when the task is switches out.
+    pub(crate) fn new_init(name: String) -> AxTaskRef {
+        let mut t = Self::new_common(TaskId::new(), name);
+        t.is_init = true;
+        if t.name == "idle" {
+            t.is_idle = true;
+        }
+        Arc::new(AxTask::new(t))
+    }
+
+    #[inline]
+    pub(crate) fn state(&self) -> TaskState {
+        self.state.load(Ordering::Acquire).into()
+    }
+
+    #[inline]
+    pub(crate) fn set_state(&self, state: TaskState) {
+        self.state.store(state as u8, Ordering::Release)
+    }
+
+    #[inline]
+    pub(crate) fn is_running(&self) -> bool {
+        matches!(self.state(), TaskState::Running)
+    }
+
+    #[inline]
+    pub(crate) fn is_ready(&self) -> bool {
+        matches!(self.state(), TaskState::Ready)
+    }
+
+    #[inline]
+    pub(crate) fn is_blocked(&self) -> bool {
+        matches!(self.state(), TaskState::Blocked)
+    }
+
+    #[inline]
+    pub(crate) const fn is_init(&self) -> bool {
+        self.is_init
+    }
+
+    #[inline]
+    pub(crate) const fn is_idle(&self) -> bool {
+        self.is_idle
+    }
+
+    #[inline]
+    pub(crate) fn in_wait_queue(&self) -> bool {
+        self.in_wait_queue.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    pub(crate) fn set_in_wait_queue(&self, in_wait_queue: bool) {
+        self.in_wait_queue.store(in_wait_queue, Ordering::Release);
+    }
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    pub(crate) fn in_timer_list(&self) -> bool {
+        self.in_timer_list.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    #[cfg(feature = "irq")]
+    pub(crate) fn set_in_timer_list(&self, in_timer_list: bool) {
+        self.in_timer_list.store(in_timer_list, Ordering::Release);
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
+    pub(crate) fn set_preempt_pending(&self, pending: bool) {
+        self.need_resched.store(pending, Ordering::Release)
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
+    pub(crate) fn can_preempt(&self, current_disable_count: usize) -> bool {
+        self.preempt_disable_count.load(Ordering::Acquire) == current_disable_count
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
+    pub(crate) fn disable_preempt(&self) {
+        self.preempt_disable_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    #[cfg(feature = "preempt")]
+    pub(crate) fn enable_preempt(&self, resched: bool) {
+        if self.preempt_disable_count.fetch_sub(1, Ordering::Relaxed) == 1 && resched {
+            // If current task is pending to be preempted, do rescheduling.
+            Self::current_check_preempt_pending();
+        }
+    }
+
+    #[cfg(feature = "preempt")]
+    fn current_check_preempt_pending() {
+        let curr = crate::current();
+        if curr.need_resched.load(Ordering::Acquire) && curr.can_preempt(0) {
+            let mut rq = crate::RUN_QUEUE.lock();
+            if curr.need_resched.load(Ordering::Acquire) {
+                rq.preempt_resched();
+            }
+        }
+    }
+
+    pub(crate) fn notify_exit(&self, exit_code: i32, rq: &mut AxRunQueue) {
+        self.exit_code.store(exit_code, Ordering::Release);
+        self.wait_for_exit.notify_all_locked(false, rq);
+    }
+
+    #[inline]
+    pub(crate) const unsafe fn ctx_mut_ptr(&self) -> *mut TaskContext {
+        self.ctx.get()
+    }
+}
+
+impl fmt::Debug for TaskInner {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TaskInner")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("state", &self.state())
+            .finish()
+    }
+}
+
+impl Drop for TaskInner {
+    fn drop(&mut self) {
+        debug!("task drop: {}", self.id_name());
+    }
+}
+
+struct TaskStack {
+    ptr: NonNull<u8>,
+    layout: Layout,
+}
+
+impl TaskStack {
+    pub fn alloc(size: usize) -> Self {
+        let layout = Layout::from_size_align(size, 16).unwrap();
+        Self {
+            ptr: NonNull::new(unsafe { alloc::alloc::alloc(layout) }).unwrap(),
+            layout,
+        }
+    }
+
+    pub const fn top(&self) -> VirtAddr {
+        unsafe { core::mem::transmute(self.ptr.as_ptr().add(self.layout.size())) }
+    }
+}
+
+impl Drop for TaskStack {
+    fn drop(&mut self) {
+        unsafe { alloc::alloc::dealloc(self.ptr.as_ptr(), self.layout) }
+    }
+}
+
+use core::mem::ManuallyDrop;
+
+/// A wrapper of [`AxTaskRef`] as the current task.
+pub struct CurrentTask(ManuallyDrop<AxTaskRef>);
+
+impl CurrentTask {
+    pub(crate) fn try_get() -> Option<Self> {
+        let ptr: *const super::AxTask = axhal::cpu::current_task_ptr();
+        if !ptr.is_null() {
+            Some(Self(unsafe { ManuallyDrop::new(AxTaskRef::from_raw(ptr)) }))
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn get() -> Self {
+        Self::try_get().expect("current task is uninitialized")
+    }
+
+    /// Converts [`CurrentTask`] to [`AxTaskRef`].
+    pub fn as_task_ref(&self) -> &AxTaskRef {
+        &self.0
+    }
+
+    pub(crate) fn clone(&self) -> AxTaskRef {
+        self.0.deref().clone()
+    }
+
+    pub(crate) fn ptr_eq(&self, other: &AxTaskRef) -> bool {
+        Arc::ptr_eq(&self.0, other)
+    }
+
+    pub(crate) unsafe fn init_current(init_task: AxTaskRef) {
+        #[cfg(feature = "tls")]
+        axhal::arch::write_thread_pointer(init_task.tls.tls_ptr() as usize);
+        let ptr = Arc::into_raw(init_task);
+        axhal::cpu::set_current_task_ptr(ptr);
+    }
+
+    pub(crate) unsafe fn set_current(prev: Self, next: AxTaskRef) {
+        let Self(arc) = prev;
+        ManuallyDrop::into_inner(arc); // `call Arc::drop()` to decrease prev task reference count.
+        let ptr = Arc::into_raw(next);
+        axhal::cpu::set_current_task_ptr(ptr);
+    }
+}
+
+impl Deref for CurrentTask {
+    type Target = TaskInner;
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+extern "C" fn task_entry() -> ! {
+    // release the lock that was implicitly held across the reschedule
+    unsafe { crate::RUN_QUEUE.force_unlock() };
+    #[cfg(feature = "irq")]
+    axhal::arch::enable_irqs();
+    let task = crate::current();
+    if let Some(entry) = task.entry {
+        unsafe { Box::from_raw(entry)() };
+    }
+    crate::exit(0);
+}

--- a/platforms/riscv64-qemu-virt.toml
+++ b/platforms/riscv64-qemu-virt.toml
@@ -8,7 +8,7 @@ family = "riscv64-qemu-virt"
 # Base address of the whole physical memory.
 phys-memory-base = "0x8000_0000"
 # Size of the whole physical memory.
-phys-memory-size = "0x800_0000"     # 128M
+phys-memory-size = "0x8000_0000"     # 2G
 # Base physical address of the kernel image.
 kernel-base-paddr = "0x8020_0000"
 # Base virtual address of the kernel image.

--- a/scripts/make/qemu.mk
+++ b/scripts/make/qemu.mk
@@ -24,7 +24,7 @@ qemu_args-aarch64 := \
   -machine virt \
   -kernel $(OUT_BIN)
 
-qemu_args-y := -m 128M -smp $(SMP) $(qemu_args-$(ARCH))
+qemu_args-y := -m 2G -smp $(SMP) $(qemu_args-$(ARCH))
 
 qemu_args-$(BLK) += \
   -device virtio-blk-$(vdev-suffix),drive=disk0 \


### PR DESCRIPTION
为任务调度模块添加了异步支持。可以调用`axstd::thread::spawn_async`函数生成异步任务。

目前还不支持多核，之后准备添加多核支持。

在`apps`中增加一个应用`axtask-test`，测试修改后的模块的任务的调度。其正常运行结果为：spawn的3个线程和3个协程轮流输出字符串。