### PR TITLE
添加数个功能

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,17 @@ dependencies = [
 name = "ats-intc"
 version = "0.1.0"
 dependencies = [
- "ats-intc-pac",
+ "ats-intc-pac 0.1.0",
+ "crossbeam",
+ "log",
+]
+
+[[package]]
+name = "ats-intc"
+version = "0.1.0"
+source = "git+https://github.com/rosy233333/ats-intc?branch=axu15eg#4fb5a81137f51b9101304438e1550c1d7a1ef0af"
+dependencies = [
+ "ats-intc-pac 0.1.0 (git+https://github.com/rosy233333/ats-intc?branch=axu15eg)",
  "crossbeam",
  "log",
 ]
@@ -249,7 +259,7 @@ dependencies = [
 name = "ats-intc-executor"
 version = "0.1.0"
 dependencies = [
- "ats-intc",
+ "ats-intc 0.1.0",
  "axstd",
  "crossbeam-utils",
 ]
@@ -263,10 +273,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ats-intc-pac"
+version = "0.1.0"
+source = "git+https://github.com/rosy233333/ats-intc?branch=axu15eg#4fb5a81137f51b9101304438e1550c1d7a1ef0af"
+dependencies = [
+ "cortex-m",
+ "vcell",
+]
+
+[[package]]
 name = "ats-intc-test"
 version = "0.1.0"
 dependencies = [
- "ats-intc",
+ "ats-intc 0.1.0",
  "axstd",
 ]
 
@@ -522,7 +541,7 @@ dependencies = [
 name = "axtask"
 version = "0.1.0"
 dependencies = [
- "ats-intc",
+ "ats-intc 0.1.0 (git+https://github.com/rosy233333/ats-intc?branch=axu15eg)",
  "axconfig",
  "axhal",
  "axtask",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,9 @@ dependencies = [
 [[package]]
 name = "ats-intc"
 version = "0.1.0"
-source = "git+https://github.com/rosy233333/ats-intc?branch=axu15eg#4fb5a81137f51b9101304438e1550c1d7a1ef0af"
+source = "git+https://github.com/ATS-INTC/ats-intc?branch=axu15eg#94cce6039bf261af8fc769bb5426982c0bcf51db"
 dependencies = [
- "ats-intc-pac 0.1.0 (git+https://github.com/rosy233333/ats-intc?branch=axu15eg)",
+ "ats-intc-pac 0.1.0 (git+https://github.com/ATS-INTC/ats-intc?branch=axu15eg)",
  "crossbeam",
  "log",
 ]
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "ats-intc-pac"
 version = "0.1.0"
-source = "git+https://github.com/rosy233333/ats-intc?branch=axu15eg#4fb5a81137f51b9101304438e1550c1d7a1ef0af"
+source = "git+https://github.com/ATS-INTC/ats-intc?branch=axu15eg#94cce6039bf261af8fc769bb5426982c0bcf51db"
 dependencies = [
  "cortex-m",
  "vcell",
@@ -541,7 +541,7 @@ dependencies = [
 name = "axtask"
 version = "0.1.0"
 dependencies = [
- "ats-intc 0.1.0 (git+https://github.com/rosy233333/ats-intc?branch=axu15eg)",
+ "ats-intc 0.1.0 (git+https://github.com/ATS-INTC/ats-intc?branch=axu15eg)",
  "axconfig",
  "axhal",
  "axtask",

--- a/api/arceos_posix_api/src/imp/pthread/mod.rs
+++ b/api/arceos_posix_api/src/imp/pthread/mod.rs
@@ -13,10 +13,10 @@ pub mod mutex;
 lazy_static::lazy_static! {
     static ref TID_TO_PTHREAD: RwLock<BTreeMap<u64, ForceSendSync<ctypes::pthread_t>>> = {
         let mut map = BTreeMap::new();
-        let main_task = axtask::current();
-        let main_tid = main_task.id().as_u64();
+        let main_task = axtask::current().unwrap();
+        let main_tid = axtask::current_id().unwrap();
         let main_thread = Pthread {
-            inner: main_task.as_task_ref().clone(),
+            inner: main_task.clone(),
             retval: Arc::new(Packet {
                 result: UnsafeCell::new(core::ptr::null_mut()),
             }),
@@ -71,7 +71,7 @@ impl Pthread {
     }
 
     fn current_ptr() -> *mut Pthread {
-        let tid = axtask::current().id().as_u64();
+        let tid = axtask::current_id().unwrap();
         match TID_TO_PTHREAD.read().get(&tid) {
             None => core::ptr::null_mut(),
             Some(ptr) => ptr.0 as *mut Pthread,
@@ -94,7 +94,7 @@ impl Pthread {
         }
 
         let thread = unsafe { Box::from_raw(ptr as *mut Pthread) };
-        thread.inner.join();
+        thread.inner.join_sync();
         let tid = thread.inner.id().as_u64();
         let retval = unsafe { *thread.retval.result.get() };
         TID_TO_PTHREAD.write().remove(&tid);

--- a/api/arceos_posix_api/src/imp/pthread/mod.rs
+++ b/api/arceos_posix_api/src/imp/pthread/mod.rs
@@ -72,6 +72,7 @@ impl Pthread {
 
     fn current_ptr() -> *mut Pthread {
         let tid = axtask::current_id().unwrap();
+        
         match TID_TO_PTHREAD.read().get(&tid) {
             None => core::ptr::null_mut(),
             Some(ptr) => ptr.0 as *mut Pthread,

--- a/api/arceos_posix_api/src/imp/pthread/mutex.rs
+++ b/api/arceos_posix_api/src/imp/pthread/mutex.rs
@@ -6,10 +6,10 @@ use axsync::Mutex;
 use core::ffi::c_int;
 use core::mem::{size_of, ManuallyDrop};
 
-static_assertions::const_assert_eq!(
-    size_of::<PthreadMutex>(),
-    size_of::<ctypes::pthread_mutex_t>()
-);
+// static_assertions::const_assert_eq!(
+//     size_of::<PthreadMutex>(),
+//     size_of::<ctypes::pthread_mutex_t>()
+// );
 
 #[repr(C)]
 pub struct PthreadMutex(Mutex<()>);

--- a/api/arceos_posix_api/src/imp/task.rs
+++ b/api/arceos_posix_api/src/imp/task.rs
@@ -21,7 +21,7 @@ pub fn sys_getpid() -> c_int {
     syscall_body!(sys_getpid,
         #[cfg(feature = "multitask")]
         {
-            Ok(axtask::current().id().as_u64() as c_int)
+            Ok(axtask::current_id().unwrap() as c_int)
         }
         #[cfg(not(feature = "multitask"))]
         {

--- a/apps/ats-intc-executor/Cargo.toml
+++ b/apps/ats-intc-executor/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 axstd = {path = "../../ulib/axstd", features = ["paging", "alloc"]}
 crossbeam-utils = {version = "0.8", default-features = false}
-ats-intc = {path = "../../../ats-intc", default-features = false, features = ["no-simul"]}
+ats-intc = {path = "../../../ats-intc", default-features = false}

--- a/apps/ats-intc-test/Cargo.toml
+++ b/apps/ats-intc-test/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 axstd = { path = "../../ulib/axstd", features = ["paging"]}
-ats-intc = { path = "../../../ats-intc", default-features = false, features = ["no-simul", "task-as-usize"] }
+ats-intc = { path = "../../../ats-intc", default-features = false, features = ["task-as-usize"] }
 
 

--- a/apps/ats-intc-test/src/main.rs
+++ b/apps/ats-intc-test/src/main.rs
@@ -4,7 +4,8 @@
 extern crate alloc;
 
 use alloc::{boxed::Box, sync::Arc};
-use ats_intc::{AtsDriver, Task};
+// use ats_intc::{AtsIntc, Task, TaskRef};
+use ats_intc::AtsIntc;
 use axstd::*;
 use sync::atomic::Ordering;
 
@@ -147,25 +148,27 @@ pub fn test_mmio_region() {
 
 pub fn test_lib() {
     let executor_base: usize = 0xffff_ffc0_0f00_0000;
-    let lite_executor: AtsDriver = AtsDriver::new(executor_base);
-    // let task0 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
-    // let task1 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
-    // let task2 = Task::new(Box::pin(empty_future()), 2, ats_intc::TaskType::Other);
-    // let task3 = Task::new(Box::pin(empty_future()), 3, ats_intc::TaskType::Other);
-    // let task4 = Task::new(Box::pin(empty_future()), 0, ats_intc::TaskType::Other);
-    let task0: usize = 0;
-    let task1: usize = 1;
-    let task2: usize = 2;
-    let task3: usize = 3;
-    let task4: usize = 4;
+    let lite_executor: AtsIntc = AtsIntc::new(executor_base);
+
+    // let task0 = unsafe { TaskRef::virt_task(1) };
+    // let task1 = unsafe { TaskRef::virt_task(2) };
+    // let task2 = unsafe { TaskRef::virt_task(3) };
+    // let task3 = unsafe { TaskRef::virt_task(4) };
+    // let task4 = unsafe { TaskRef::virt_task(5) };
+
+    let task0: usize = 1;
+    let task1: usize = 2;
+    let task2: usize = 3;
+    let task3: usize = 4;
+    let task4: usize  = 5;
     
     // unsafe { (&*task1.as_ptr()).update_priority(1); }
 
-    lite_executor.load_handler(10, task0);
-    lite_executor.stask(task3, 0 , 3);
-    lite_executor.stask(task2, 0 , 2);
-    lite_executor.stask(task1, 0 , 1);
-    lite_executor.stask(task4, 0 , 0);
+    lite_executor.intr_push(10, task0);
+    lite_executor.ps_push(task3, 3);
+    lite_executor.ps_push(task2 , 2);
+    lite_executor.ps_push(task1 , 1);
+    lite_executor.ps_push(task4 , 0);
 
     // unsafe {
     //     println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
@@ -175,11 +178,11 @@ pub fn test_lib() {
     //     println!("{:?}", (*lite_executor.ftask(0).unwrap().as_ptr()).priority.load(Ordering::Acquire));
     // }
 
-    println!("{:?}", lite_executor.ftask(0).unwrap());
-    println!("{:?}", lite_executor.ftask(0).unwrap());
-    println!("{:?}", lite_executor.ftask(0).unwrap());
-    println!("{:?}", lite_executor.ftask(0).unwrap());
-    // println!("{:?}", lite_executor.ftask(0).unwrap());
+    println!("{:?}", lite_executor.ps_fetch().unwrap());
+    println!("{:?}", lite_executor.ps_fetch().unwrap());
+    println!("{:?}", lite_executor.ps_fetch().unwrap());
+    println!("{:?}", lite_executor.ps_fetch().unwrap());
+    println!("{:?}", lite_executor.ps_fetch().unwrap());
 }
 
 async fn empty_future() -> i32 {0}

--- a/apps/axtask-test/Cargo.toml
+++ b/apps/axtask-test/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axstd = { path = "../../ulib/axstd", features = ["paging", "alloc", "multitask"] }
+axstd = { path = "../../ulib/axstd", features = ["paging", "alloc", "multitask", "irq"] }
 # axstd = { path = "../../ulib/axstd", features = ["paging", "alloc"] }

--- a/apps/axtask-test/src/main.rs
+++ b/apps/axtask-test/src/main.rs
@@ -7,6 +7,7 @@ use core::future::Future;
 use core::sync::atomic::AtomicBool;
 use core::sync::atomic::Ordering;
 use core::task::Poll;
+use core::time::Duration;
 
 use alloc::string::String;
 use alloc::string::ToString;
@@ -16,11 +17,18 @@ use axstd::thread;
 #[no_mangle]
 fn main() {
     println!("0.1");
+    // thread::spawn(|| {
+    //     println!("1.1");
+    //     thread::yield_now();
+    //     println!("1.2");
+    //     thread::yield_now();
+    //     println!("1.3");
+    // });
     thread::spawn(|| {
         println!("1.1");
-        thread::yield_now();
+        thread::sleep(Duration::from_secs(1));
         println!("1.2");
-        thread::yield_now();
+        thread::sleep(Duration::from_secs(1));
         println!("1.3");
     });
     thread::spawn(|| {

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -195,7 +195,7 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
         axtask::spawn_init(|| { 
             unsafe{ 
                 main();
-                axtask::exit(0);
+                // axhal::misc::terminate();
             } 
         });
         info!("multitask start run executor");

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -199,7 +199,7 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
             } 
         });
         info!("multitask start run executor");
-        axtask::run_executor();
+        axtask::run_executor(cpu_id);
     }
     
     #[cfg(not(feature = "multitask"))]

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -39,8 +39,8 @@ pub extern "C" fn rust_main_secondary(cpu_id: usize) -> ! {
 
     axhal::platform_init_secondary();
 
-    #[cfg(feature = "multitask")]
-    axtask::init_scheduler_secondary();
+    // #[cfg(feature = "multitask")]
+    // axtask::init_scheduler_secondary();
 
     info!("Secondary CPU {:x} init OK.", cpu_id);
     super::INITED_CPUS.fetch_add(1, Ordering::Relaxed);
@@ -56,7 +56,10 @@ pub extern "C" fn rust_main_secondary(cpu_id: usize) -> ! {
     super::init_tls();
 
     #[cfg(feature = "multitask")]
-    axtask::run_idle();
+    {
+        info!("multitask start run executor");
+        axtask::run_executor(cpu_id);
+    }
     #[cfg(not(feature = "multitask"))]
     loop {
         axhal::arch::wait_for_irqs();

--- a/modules/axsync/src/mutex.rs
+++ b/modules/axsync/src/mutex.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use axtask::{current, WaitQueue};
+use axtask::{current_id, WaitQueue};
 
 /// A mutual exclusion primitive useful for protecting shared data, similar to
 /// [`std::sync::Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html).
@@ -69,7 +69,7 @@ impl<T: ?Sized> Mutex<T> {
     /// The returned value may be dereferenced for data access
     /// and the lock will be dropped when the guard falls out of scope.
     pub fn lock(&self) -> MutexGuard<T> {
-        let current_id = current().unwrap().id().as_u64();
+        let current_id = current_id().unwrap();
         loop {
             // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
             // when called in a loop.
@@ -85,7 +85,7 @@ impl<T: ?Sized> Mutex<T> {
                         owner_id,
                         current_id,
                         "{} tried to acquire mutex it already owns.",
-                        current().unwrap().id_name()
+                        current_id
                     );
                     // Wait until the lock looks unlocked before retrying
                     self.wq.wait_until(|| !self.is_locked());
@@ -101,7 +101,7 @@ impl<T: ?Sized> Mutex<T> {
     /// Try to lock this [`Mutex`], returning a lock guard if successful.
     #[inline(always)]
     pub fn try_lock(&self) -> Option<MutexGuard<T>> {
-        let current_id = current().unwrap().id().as_u64();
+        let current_id = current_id().unwrap();
         // The reason for using a strong compare_exchange is explained here:
         // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
         if self
@@ -129,9 +129,9 @@ impl<T: ?Sized> Mutex<T> {
         let owner_id = self.owner_id.swap(0, Ordering::Release);
         assert_eq!(
             owner_id,
-            current().unwrap().id().as_u64(),
+            current_id().unwrap(),
             "{} tried to release mutex it doesn't own",
-            current().unwrap().id_name()
+            current_id().unwrap()
         );
         self.wq.notify_one(true);
     }

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -39,7 +39,7 @@ scheduler = { path = "../../crates/scheduler", optional = true }
 timer_list = { path = "../../crates/timer_list", optional = true }
 kernel_guard = { path = "../../crates/kernel_guard", optional = true }
 crate_interface = { path = "../../crates/crate_interface", optional = true }
-ats-intc = { path = "../../../ats-intc", default-features = false, features = ["task-as-usize"], optional = true }
+ats-intc = { git = "https://github.com/rosy233333/ats-intc", branch = "axu15eg", default-features = false, features = ["task-as-usize"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -39,7 +39,7 @@ scheduler = { path = "../../crates/scheduler", optional = true }
 timer_list = { path = "../../crates/timer_list", optional = true }
 kernel_guard = { path = "../../crates/kernel_guard", optional = true }
 crate_interface = { path = "../../crates/crate_interface", optional = true }
-ats-intc = { git = "https://github.com/rosy233333/ats-intc", branch = "axu15eg", default-features = false, features = ["task-as-usize"], optional = true }
+ats-intc = { git = "https://github.com/ATS-INTC/ats-intc", branch = "axu15eg", optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -39,7 +39,7 @@ scheduler = { path = "../../crates/scheduler", optional = true }
 timer_list = { path = "../../crates/timer_list", optional = true }
 kernel_guard = { path = "../../crates/kernel_guard", optional = true }
 crate_interface = { path = "../../crates/crate_interface", optional = true }
-ats-intc = { path = "../../../ats-intc", default-features = false, features = ["no-simul", "task-as-usize"], optional = true }
+ats-intc = { path = "../../../ats-intc", default-features = false, features = ["task-as-usize"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -1,7 +1,7 @@
 //! Task APIs for multi-task configuration.
 
 use alloc::{string::String, sync::Arc};
-use ats_intc::AtsDriver;
+use ats_intc::AtsIntc;
 
 use crate::ats::{Ats, ATS_DRIVER, ATS_EXECUTOR, CURRENT_TASK};
 // pub(crate) use crate::run_queue::{AxRunQueue, RUN_QUEUE};
@@ -62,7 +62,7 @@ use core::future::Future;
 
 /// Init the scheduler/executor.
 pub fn init() {
-    ATS_DRIVER.init_by(AtsDriver::new(0xffff_ffc0_0f00_0000));
+    ATS_DRIVER.init_by(AtsIntc::new(0xffff_ffc0_0f00_0000));
     ATS_EXECUTOR.init_by(Ats::new(PROCESS_ID));
     CURRENT_TASK.init_by(CurrentTask::new());
 }
@@ -118,7 +118,7 @@ where
     let task = TaskInner::new(f, name, stack_size);
     let priority = task.inner.get_priority();
     let task_ref = Arc::into_raw(task.clone()) as *const () as usize;
-    ATS_DRIVER.stask(task_ref, PROCESS_ID, priority);
+    ATS_DRIVER.ps_push(task_ref, priority);
     task
 }
 
@@ -129,7 +129,7 @@ where
     let task = TaskInner::new_init(f, name, stack_size);
     let priority = task.inner.get_priority();
     let task_ref = Arc::into_raw(task.clone()) as *const () as usize;
-    ATS_DRIVER.stask(task_ref, PROCESS_ID, priority);
+    ATS_DRIVER.ps_push(task_ref, priority);
     task
 }
 
@@ -163,7 +163,7 @@ where
     let task = AsyncTaskInner::new(f, name);
     let priority = task.inner.get_priority();
     let task_ref = Arc::into_raw(task.clone()) as *const () as usize;
-    ATS_DRIVER.stask(task_ref, PROCESS_ID, priority);
+    ATS_DRIVER.ps_push(task_ref, priority);
     task
 }
 

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -130,7 +130,7 @@ where
 {
     let task = TaskInner::new(f, name, stack_size);
     let priority = task.inner.get_priority();
-    let task_ref = Arc::into_raw(task.clone()) as *const () as usize;
+    let task_ref = task.clone().into_task_ref();
     ATS_DRIVER.ps_push(task_ref, priority);
     task
 }
@@ -141,7 +141,7 @@ where
 {
     let task = TaskInner::new_init(f, name, stack_size);
     let priority = task.inner.get_priority();
-    let task_ref = Arc::into_raw(task.clone()) as *const () as usize;
+    let task_ref = task.clone().into_task_ref();
     ATS_DRIVER.ps_push(task_ref, priority);
     task
 }
@@ -175,7 +175,7 @@ where
 {
     let task = AsyncTaskInner::new(f, name);
     let priority = task.inner.get_priority();
-    let task_ref = Arc::into_raw(task.clone()) as *const () as usize;
+    let task_ref = task.clone().into_task_ref();
     ATS_DRIVER.ps_push(task_ref, priority);
     task
 }

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -87,7 +87,7 @@ pub fn current() -> Option<AxTaskRef> {
 
 /// Gets the current task id.
 pub fn current_id() -> Option<u64> {
-    current().map(|t|{ t.id().as_u64() })
+    Some(current().map(|t|{ t.id().as_u64() }).unwrap_or(0))
 }
 
 // /// Initializes the task scheduler (for the primary CPU).

--- a/modules/axtask/src/ats.rs
+++ b/modules/axtask/src/ats.rs
@@ -66,9 +66,9 @@ impl Ats {
                     }
                 },
                 None => {
-                    info!("  ftask: None");
+                    // info!("  ftask: None");
                     // spin_loop();
-                    axhal::misc::terminate();
+                    // axhal::misc::terminate();
                 }
             }
         }

--- a/modules/axtask/src/ats.rs
+++ b/modules/axtask/src/ats.rs
@@ -1,6 +1,6 @@
 ﻿use core::{cell::{RefCell, UnsafeCell}, hint::spin_loop, task::Poll};
 use ats_intc::AtsIntc;
-use axhal::arch::TaskContext;
+use axhal::{arch::TaskContext, cpu::this_cpu_id};
 use lazy_init::LazyInit;
 use spinlock::SpinNoIrq;
 use crate::{task::{AbsTaskInner, AxTask, TaskStack}, AxTaskRef, CurrentTask, WaitQueue};
@@ -8,6 +8,7 @@ use core::task::{ Context, Waker };
 use alloc::{collections::VecDeque, sync::Arc};
 use core::arch::asm;
 use memory_addr::align_up_4k;
+use alloc::vec::Vec;
 
 // pub(crate) static ATS_DRIVER: Lazy<AtsDriver> = Lazy::new(| |{ AtsDriver::new(0xffff_ffc0_0f00_0000) });
 pub(crate) static ATS_DRIVER: LazyInit<AtsIntc> = LazyInit::new();
@@ -16,8 +17,8 @@ pub(crate) const PROCESS_ID: usize = 0;
 // scheduler and executor
 // pub(crate) static ATS_EXECUTOR: Lazy<Ats> = Lazy::new(| |{ Ats::new(PROCESS_ID) });
 // pub(crate) static CURRENT_TASK: Lazy<RefCell<CurrentTask>> = Lazy::new(| |{ RefCell::new(CurrentTask::new()) });
-pub(crate) static ATS_EXECUTOR: LazyInit<Ats> = LazyInit::new();
-pub(crate) static CURRENT_TASK: LazyInit<CurrentTask> = LazyInit::new();
+pub(crate) static ATS_EXECUTORS: LazyInit<Vec<Ats>> = LazyInit::new();
+pub(crate) static CURRENT_TASKS: LazyInit<Vec<CurrentTask>> = LazyInit::new();
 
 // TODO: per-CPU
 pub(crate) static EXITED_TASKS: SpinNoIrq<VecDeque<AxTaskRef>> = SpinNoIrq::new(VecDeque::new());
@@ -43,17 +44,18 @@ impl Ats {
     }
 
     pub(crate) fn run(&self) -> ! {
+        let cpu_id = this_cpu_id();
         loop {
-            info!("  into Ats::run");
+            // info!("  into Ats::run");
             let task = ATS_DRIVER.ps_fetch();
-            info!("  after ftask");
+            // info!("  after ftask");
             match task {
                 Some(task_ref) => {
                     unsafe {
                         info!("  ftask: Some");
                         let task: Arc<AxTask> = Arc::from_raw(task_ref as *const AxTask);
                         info!("  fetch task: {}.", task.id_name());
-                        CURRENT_TASK.set_current(Some(task.clone()));
+                        CURRENT_TASKS[cpu_id].set_current(Some(task.clone()));
                         match task.poll(&mut Context::from_waker(&Waker::from(task.clone()))) { 
                             Poll::Ready(value) => {
                                 info!("  task return {}.", value);
@@ -62,7 +64,7 @@ impl Ats {
                                 info!("  task not finished.");
                             },
                         }
-                        CURRENT_TASK.set_current(None);
+                        CURRENT_TASKS[cpu_id].set_current(None);
                     }
                 },
                 None => {
@@ -72,5 +74,12 @@ impl Ats {
                 }
             }
         }
+    }
+}
+
+/// Only used for initialization
+impl Clone for Ats {
+    fn clone(&self) -> Self {
+        Self::new(self.process_id)
     }
 }

--- a/modules/axtask/src/ats.rs
+++ b/modules/axtask/src/ats.rs
@@ -1,5 +1,5 @@
 ﻿use core::{cell::{RefCell, UnsafeCell}, hint::spin_loop, task::Poll};
-use ats_intc::AtsDriver;
+use ats_intc::AtsIntc;
 use axhal::arch::TaskContext;
 use lazy_init::LazyInit;
 use spinlock::SpinNoIrq;
@@ -10,7 +10,7 @@ use core::arch::asm;
 use memory_addr::align_up_4k;
 
 // pub(crate) static ATS_DRIVER: Lazy<AtsDriver> = Lazy::new(| |{ AtsDriver::new(0xffff_ffc0_0f00_0000) });
-pub(crate) static ATS_DRIVER: LazyInit<AtsDriver> = LazyInit::new();
+pub(crate) static ATS_DRIVER: LazyInit<AtsIntc> = LazyInit::new();
 pub(crate) const PROCESS_ID: usize = 0;
 
 // scheduler and executor
@@ -45,7 +45,7 @@ impl Ats {
     pub(crate) fn run(&self) -> ! {
         loop {
             info!("  into Ats::run");
-            let task = ATS_DRIVER.ftask(self.process_id);
+            let task = ATS_DRIVER.ps_fetch();
             info!("  after ftask");
             match task {
                 Some(task_ref) => {

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -985,7 +985,7 @@ impl CurrentTask {
     //     self.0.map(|a| { ManuallyDrop::into_inner(a) })
     // }
 
-    pub(crate) fn clone(&self) -> Option<AxTaskRef> {
+    pub(crate) fn get_clone(&self) -> Option<AxTaskRef> {
         self.0.borrow().as_deref().map(|a| { a.clone() })
     }
 
@@ -1022,6 +1022,14 @@ impl CurrentTask {
 
 unsafe impl Send for CurrentTask { }
 unsafe impl Sync for CurrentTask { }
+
+/// Only used for initialization
+impl Clone for CurrentTask {
+    fn clone(&self) -> Self {
+        assert!(self.0.borrow().is_none());
+        Self::new()
+    }
+}
 
 extern "C" fn task_entry() -> ! {
     // // release the lock that was implicitly held across the reschedule

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -10,7 +10,7 @@ use core::task::{Context, Poll};
 use core::{alloc::Layout, cell::UnsafeCell, fmt, ptr::NonNull};
 
 use core::arch::asm;
-use ats_intc::AtsDriver;
+use ats_intc::AtsIntc;
 
 #[cfg(feature = "preempt")]
 use core::sync::atomic::AtomicUsize;
@@ -39,7 +39,7 @@ impl Wake for AxTask {
         self.inner.set_state(TaskState::Ready);
         let priority = self.inner.get_priority();
         let task_ref = Arc::into_raw(self) as *const _ as usize;
-        ATS_DRIVER.stask(task_ref, PROCESS_ID, priority);
+        ATS_DRIVER.ps_push(task_ref, priority);
     }
 }
 
@@ -127,7 +127,7 @@ impl AxTask {
         self.set_state(TaskState::Ready);
 
         let priority = self.get_priority();
-        ATS_DRIVER.stask(Arc::into_raw(self.clone()) as *const () as usize, PROCESS_ID, priority);
+        ATS_DRIVER.ps_push(Arc::into_raw(self.clone()) as *const () as usize, priority);
 
         unsafe {
             

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -174,6 +174,14 @@ impl AxTask {
         }
     }
 
+    pub fn join_sync(&self) -> Option<i32> {
+        assert!(!self.is_async());
+        unsafe {
+            let inner = &*(self.inner.as_ref() as *const dyn AbsTaskInner as *const () as *const TaskInner);
+            inner.join()
+        }
+    }
+
     /// This function should be called after this task is added into a block queue. Otherwise, task won't wake.
     pub(crate) fn sync_block(self: Arc<Self>) {
         assert!(!self.is_async());

--- a/modules/axtask/src/timers.rs
+++ b/modules/axtask/src/timers.rs
@@ -4,7 +4,7 @@ use lazy_init::LazyInit;
 use spinlock::SpinNoIrq;
 use timer_list::{TimeValue, TimerEvent, TimerList};
 
-use crate::{AxTaskRef, RUN_QUEUE};
+use crate::{ats::ATS_DRIVER, task::AxTask, AxTaskRef};
 
 // TODO: per-CPU
 static TIMER_LIST: LazyInit<SpinNoIrq<TimerList<TaskWakeupEvent>>> = LazyInit::new();
@@ -13,9 +13,11 @@ struct TaskWakeupEvent(AxTaskRef);
 
 impl TimerEvent for TaskWakeupEvent {
     fn callback(self, _now: TimeValue) {
-        let mut rq = RUN_QUEUE.lock();
+        // let mut rq = RUN_QUEUE.lock();
         self.0.set_in_timer_list(false);
-        rq.unblock_task(self.0, true);
+        let priority = self.0.get_priority();
+        ATS_DRIVER.ps_push(Arc::into_raw(self.0) as *const AxTask as usize, priority);
+        // rq.unblock_task(self.0, true);
     }
 }
 

--- a/modules/axtask/src/timers.rs
+++ b/modules/axtask/src/timers.rs
@@ -16,7 +16,8 @@ impl TimerEvent for TaskWakeupEvent {
         // let mut rq = RUN_QUEUE.lock();
         self.0.set_in_timer_list(false);
         let priority = self.0.get_priority();
-        ATS_DRIVER.ps_push(Arc::into_raw(self.0) as *const AxTask as usize, priority);
+        let task_ref = self.0.into_task_ref();
+        ATS_DRIVER.ps_push(task_ref, priority);
         // rq.unblock_task(self.0, true);
     }
 }

--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -185,7 +185,7 @@ impl WaitQueue {
                 // rq.unblock_task(task, resched);
                 task.set_state(TaskState::Ready);
                 let priority = task.inner.get_priority();
-                ATS_DRIVER.stask(Arc::into_raw(task) as *const _ as usize, PROCESS_ID, priority);
+                ATS_DRIVER.ps_push(Arc::into_raw(task) as *const _ as usize, priority);
             } else {
                 break;
             }
@@ -204,7 +204,7 @@ impl WaitQueue {
             task.set_in_wait_queue(false);
             // rq.unblock_task(wq.remove(index).unwrap(), resched);
             task.set_state(TaskState::Ready);
-            ATS_DRIVER.stask(Arc::into_raw(task.clone()) as *const _ as usize, PROCESS_ID, task.get_priority());
+            ATS_DRIVER.ps_push(Arc::into_raw(task.clone()) as *const _ as usize, task.get_priority());
             true
         } else {
             false
@@ -217,7 +217,7 @@ impl WaitQueue {
             // rq.unblock_task(task, resched);
             task.set_state(TaskState::Ready);
             let priority = task.inner.get_priority();
-            ATS_DRIVER.stask(Arc::into_raw(task) as *const _ as usize, PROCESS_ID, priority);
+            ATS_DRIVER.ps_push(Arc::into_raw(task) as *const _ as usize, priority);
             true
         } else {
             false
@@ -230,7 +230,7 @@ impl WaitQueue {
             // rq.unblock_task(task, resched);
             task.set_state(TaskState::Ready);
             let priority = task.inner.get_priority();
-            ATS_DRIVER.stask(Arc::into_raw(task) as *const _ as usize, PROCESS_ID, priority);
+            ATS_DRIVER.ps_push(Arc::into_raw(task) as *const _ as usize, priority);
         }
     }
 }

--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -195,7 +195,8 @@ impl WaitQueue {
                 // rq.unblock_task(task, resched);
                 task.set_state(TaskState::Ready);
                 let priority = task.inner.get_priority();
-                ATS_DRIVER.ps_push(Arc::into_raw(task) as *const _ as usize, priority);
+                let task_ref = task.into_task_ref();
+                ATS_DRIVER.ps_push(task_ref, priority);
             } else {
                 break;
             }
@@ -214,7 +215,8 @@ impl WaitQueue {
             task.set_in_wait_queue(false);
             // rq.unblock_task(wq.remove(index).unwrap(), resched);
             task.set_state(TaskState::Ready);
-            ATS_DRIVER.ps_push(Arc::into_raw(task.clone()) as *const _ as usize, task.get_priority());
+            let task_ref = task.clone().into_task_ref();
+            ATS_DRIVER.ps_push(task_ref, task.get_priority());
             true
         } else {
             false
@@ -227,7 +229,8 @@ impl WaitQueue {
             // rq.unblock_task(task, resched);
             task.set_state(TaskState::Ready);
             let priority = task.inner.get_priority();
-            ATS_DRIVER.ps_push(Arc::into_raw(task) as *const _ as usize, priority);
+            let task_ref = task.into_task_ref();
+            ATS_DRIVER.ps_push(task_ref, priority);
             true
         } else {
             false
@@ -240,7 +243,8 @@ impl WaitQueue {
             // rq.unblock_task(task, resched);
             task.set_state(TaskState::Ready);
             let priority = task.inner.get_priority();
-            ATS_DRIVER.ps_push(Arc::into_raw(task) as *const _ as usize, priority);
+            let task_ref = task.into_task_ref();
+            ATS_DRIVER.ps_push(task_ref, priority);
         }
     }
 }


### PR DESCRIPTION
1. 适配更新后的`qemu`硬件和`ats-intc`驱动
2. 添加`irq` feature支持，支持时钟中断和线程睡眠
3. 添加`smp` feature支持，支持多核调度，可以在编译运行命令中添加`SMP=n`来指定核数